### PR TITLE
Diversos Ajustes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "",
   "license": "BSD-3-Clause",
   "author": {

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,8 +2,6 @@
 
 ## Geral
 
-* Validar quando são enviados valores em campos com padrão sequencia.
-* Validar no FindOptions.orderBy colunas que não existem.
 * No FindOptios.where quando for filho, filtrar os filhos também.
 * No FindOne colocar o parâmetro 'runEventAfterLoad' dentro do findOptions e mudar o nome para 'allowSubscriber'.
 * No FindOptions where poder usar um valor de relação que dai pegaria automaticamente o campo relacionado para fazer o where.

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,8 +2,6 @@
 
 ## Geral
 
-* Esta dando alguns erros de release, pesquisar.
-* Tem erro ao gerar as migrations quando tem mais de uma variavel, tem que replicar o DECLARE e remover o nome trigger do final do nome
 * Validar quando são enviados valores em campos com padrão sequencia.
 * Validar no FindOptions.orderBy colunas que não existem.
 * No FindOptios.where quando for filho, filtrar os filhos também.

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,6 +2,10 @@
 
 ## Geral
 
+* Verificar se é possível que os métodos save e delete do EntityManger sejam apenas um do tipo any ou any[].
+* No FindOptions passar internamente o queryRunner utilizado, igual ao que é feito com o método save e delete.
+* No FindOne colocar o parâmetro 'runEventAfterLoad' dentro do findOptions e mudar o nome para 'allowSubscriber'.
+* No FindOptions where poder usar um valor de relação que dai pegaria automaticamente o campo relacionado para fazer o where.
 * Verificar o método loadPrimaryKey para não criar as classes porque o objeto inteiro deveria estar criado pelo método EntityManager.create.
 * Associar ao método createEntity o método EntityManager.create para que não seja necessário passar parametros adicionais no método create.
 * Criar um erro quando o método createEntity da relation não retornar nada.

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,7 +2,6 @@
 
 ## Geral
 
-* Verificar se é possível que os métodos save e delete do EntityManger sejam apenas um do tipo any ou any[].
 * No FindOptions passar internamente o queryRunner utilizado, igual ao que é feito com o método save e delete.
 * No FindOne colocar o parâmetro 'runEventAfterLoad' dentro do findOptions e mudar o nome para 'allowSubscriber'.
 * No FindOptions where poder usar um valor de relação que dai pegaria automaticamente o campo relacionado para fazer o where.

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,7 +2,6 @@
 
 ## Geral
 
-* No FindOptions passar internamente o queryRunner utilizado, igual ao que é feito com o método save e delete.
 * No FindOne colocar o parâmetro 'runEventAfterLoad' dentro do findOptions e mudar o nome para 'allowSubscriber'.
 * No FindOptions where poder usar um valor de relação que dai pegaria automaticamente o campo relacionado para fazer o where.
 * Verificar o método loadPrimaryKey para não criar as classes porque o objeto inteiro deveria estar criado pelo método EntityManager.create.

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,6 +2,11 @@
 
 ## Geral
 
+* Esta dando alguns erros de release, pesquisar.
+* Tem erro ao gerar as migrations quando tem mais de uma variavel, tem que replicar o DECLARE e remover o nome trigger do final do nome
+* Validar quando são enviados valores em campos com padrão sequencia.
+* Validar no FindOptions.orderBy colunas que não existem.
+* No FindOptios.where quando for filho, filtrar os filhos também.
 * No FindOne colocar o parâmetro 'runEventAfterLoad' dentro do findOptions e mudar o nome para 'allowSubscriber'.
 * No FindOptions where poder usar um valor de relação que dai pegaria automaticamente o campo relacionado para fazer o where.
 * Verificar o método loadPrimaryKey para não criar as classes porque o objeto inteiro deveria estar criado pelo método EntityManager.create.

--- a/src/__tests__/02-operations/0101-insert-categories-separately.test.ts
+++ b/src/__tests__/02-operations/0101-insert-categories-separately.test.ts
@@ -11,7 +11,7 @@ describe('Insert categories separately', () => {
 	});
 
 	it('Insert categories separately', async () => {
-		let category;
+		let category: CategoryModel;
 
 		category = await connection.getEntityManager(CategoryModel).save({
 			name: 'Category 1',

--- a/src/__tests__/02-operations/0104-insert-categories-in-batch.test.ts
+++ b/src/__tests__/02-operations/0104-insert-categories-in-batch.test.ts
@@ -12,7 +12,7 @@ describe('Insert categories in batch', () => {
 
 	it('Insert categories in batch', async () => {
 
-		const categories: any = await connection.getEntityManager(CategoryModel).save([
+		const categories: CategoryModel[] = await connection.getEntityManager(CategoryModel).save([
 			{
 				name: 'Category 5',
 			},

--- a/src/__tests__/02-operations/0105-insert-categories-with-parent.test.ts
+++ b/src/__tests__/02-operations/0105-insert-categories-with-parent.test.ts
@@ -12,7 +12,7 @@ describe('Insert categories with parent', () => {
 
 	it('Insert categories with parent', async () => {
 
-		const categories: any = await connection.getEntityManager(CategoryModel).save([
+		const categories: CategoryModel[] = await connection.getEntityManager(CategoryModel).save([
 			{
 				name: 'Category 1.1',
 				parent: {
@@ -29,9 +29,9 @@ describe('Insert categories with parent', () => {
 
 		expect(categories.length).toBe(2);
 		expect(categories[0].id).toEqual('9');
-		expect(categories[0].parent.id).toEqual('1');
+		expect(categories[0].parent?.id).toEqual('1');
 		expect(categories[1].id).toEqual('10');
-		expect(categories[1].parent.id).toEqual('2');
+		expect(categories[1].parent?.id).toEqual('2');
 
 	});
 

--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -211,7 +211,6 @@ export class Connection {
 	 */
 	public async transaction<T = any>(transactionProcess: TransactionProcess<T>): Promise<T> {
 
-
 		const queryRunner: QueryRunner = await this.createQueryRunner();
 
 		try {
@@ -229,8 +228,10 @@ export class Connection {
 			if (queryRunner.inTransaction) {
 				await queryRunner.commitTransaction();
 			}
-			await queryRunner.release();
+			// await queryRunner.release();
+
 		}
+
 	}
 
 }

--- a/src/drivers/databases/postgres/postgres-driver.ts
+++ b/src/drivers/databases/postgres/postgres-driver.ts
@@ -61,7 +61,7 @@ export class PostgresDriver extends Driver {
    }
    
    public async releaseQueryRunner(client: any): Promise<void> {
-      await client.release();
+      await client?.release();
    }
    
    public async disconnect(): Promise<void> {

--- a/src/drivers/databases/postgres/postgres-query-builder-driver.ts
+++ b/src/drivers/databases/postgres/postgres-query-builder-driver.ts
@@ -149,7 +149,7 @@ export class PostgresQueryBuilderDriver extends QueryBuilderDriver {
 	}
 
 	public createTriggerFromMetadata(triggerMetadata: TriggerMetadata): string[] {
-		const variables = (triggerMetadata.trigger.variables ? `DECLARE ${triggerMetadata.trigger.variables.map((variable) => `${variable.name} ${variable.type}`).join(' ')};` : '');
+		const variables = (triggerMetadata.trigger.variables ? `DECLARE ${triggerMetadata.trigger.variables.map((variable) => `${variable.name} ${variable.type}`).join('; DECLARE ')};` : '');
 		return [
 			`CREATE FUNCTION "${triggerMetadata.entity.connection.options.schema ?? 'public'}"."${triggerMetadata.name}"() RETURNS trigger LANGUAGE 'plpgsql' VOLATILE AS $BODY$ ${variables} BEGIN ${triggerMetadata.trigger.code} END $BODY$;`,
 			`CREATE TRIGGER "${triggerMetadata.name}" ${triggerMetadata.fires} ${triggerMetadata.events.join(' OR ')} ON "${triggerMetadata.entity.connection.options.schema ?? 'public'}"."${triggerMetadata.entity.name}" FOR EACH ROW ${triggerMetadata.trigger.when ? ` WHEN ${triggerMetadata.trigger.when} ` : ''} EXECUTE FUNCTION "${triggerMetadata.entity.connection.options.schema ?? 'public'}"."${triggerMetadata.name}"();`,

--- a/src/errors/column_metadata_not_located.error.ts
+++ b/src/errors/column_metadata_not_located.error.ts
@@ -1,7 +1,18 @@
+/**
+ * Default error class when a requested column does not exist in the entity.
+ */
 export class ColumnMetadataNotLocatedError extends Error {
 
-   constructor(entityClassName: string, columnPropertyName: string) {
-      super(`ColumnMetadata '${columnPropertyName}' not found, make sure it is declared in the entity '${entityClassName}'`);
-   }
+	/**
+	 * Default class constructor
+	 * @param {string} entityClassName Entity class name or
+	 * metadata.
+	 * @param {string} columnPropertyName Entity property name that was not
+	 * found.
+	 * @param {string} location Location where the error was generated.
+	 */
+	constructor(entityClassName: string, columnPropertyName: string, location?: string) {
+		super(`ColumnMetadata '${columnPropertyName}' ${((location ?? '').length > 0 ? `informed in the ${location} ` : '')}not found, make sure it is declared in the entity '${entityClassName}'`);
+	}
 
 }

--- a/src/errors/referenced_column_metadata_not_located.error.ts
+++ b/src/errors/referenced_column_metadata_not_located.error.ts
@@ -1,7 +1,17 @@
+/**
+ * Default error class when a column referenced in a relation does not exist in the related entity
+ */
 export class ReferencedColumnMetadataNotLocatedError extends Error {
 
-   constructor(sourceEntityClassName: string, referencedEntityClassName: string, referencedColumnPropertyName: string) {
-      super(`The referenced ColumnMetadata '${referencedColumnPropertyName}' used in '${sourceEntityClassName}' entity not found, make sure it is declared in the entity '${referencedEntityClassName}'`);
-   }
+	/**
+	 * Default class constructor
+	 * @param {string} sourceEntityClassName Source entity class name.
+	 * @param {string} sourceColumnPropertyName Column name of source entity.
+	 * @param {string} referencedEntityClassName Referenced Entity class name.
+	 * @param {string} referencedColumnPropertyName Column name of related entity.
+	 */
+	constructor(sourceEntityClassName: string, sourceColumnPropertyName: string, referencedEntityClassName: string, referencedColumnPropertyName: string) {
+		super(`The referenced ColumnMetadata '${referencedColumnPropertyName}' informed in '${sourceColumnPropertyName}' column of the entity '${sourceEntityClassName}' not found, make sure it is declared in the entity '${referencedEntityClassName}'`);
+	}
 
 }

--- a/src/manager/coke-model.ts
+++ b/src/manager/coke-model.ts
@@ -362,9 +362,10 @@ export abstract class CokeModel {
 			let childrenToRemove: CokeModel[] | undefined = undefined;
 			if (columnChildRelation.relation?.canRemove) {
 				childrenToRemove = await columnChildRelation.relation.referencedEntityManager.find({
+					queryRunner: saveOptions.queryRunner,
 					relations: [columnChildRelation.relation.referencedColumn],
 					where: JSON.parse(JSON.stringify(childRelationColumn)),
-				}, saveOptions.queryRunner) as any[];
+				}) as any[];
 			}
 
 			// go through the current children to check if they exist and perform
@@ -596,10 +597,12 @@ export abstract class CokeModel {
 
 			// run the query to verify the object and verify that it exists
 			const result: any = await entityManager.findOne({
+				queryRunner,
 				select: primaryKeys,
 				where: where,
 				orderBy: orderBy,
-			}, queryRunner, false);
+				runAfterLoadEvent: false,
+			});
 
 			// If the requested object exists in the database, the primary keys will
 			// be loaded into the current object

--- a/src/manager/coke-model.ts
+++ b/src/manager/coke-model.ts
@@ -231,38 +231,62 @@ export abstract class CokeModel {
 
 			// events related to transaction commit
 			if (subscriber?.beforeTransactionCommit) {
-				const beforeTransactionCommit = subscriber.beforeTransactionCommit;
-				saveOptions.queryRunner.beforeTransactionCommit.push(() => beforeTransactionCommit(event));
+				saveOptions.queryRunner.beforeTransactionCommit.push(() => {
+					if (subscriber?.beforeTransactionCommit) {
+						subscriber.beforeTransactionCommit(event);
+					}
+				});
 			}
 			if (saveOptions?.subscriber?.beforeTransactionCommit) {
-				const beforeTransactionCommit = saveOptions.subscriber.beforeTransactionCommit;
-				saveOptions.queryRunner.beforeTransactionCommit.push(() => beforeTransactionCommit(event));
+				saveOptions.queryRunner.beforeTransactionCommit.push(() => {
+					if (saveOptions?.subscriber?.beforeTransactionCommit) {
+						saveOptions.subscriber.beforeTransactionCommit(event);
+					}
+				});
 			}
 			if (subscriber?.afterTransactionCommit) {
-				const afterTransactionCommit = subscriber.afterTransactionCommit;
-				saveOptions.queryRunner.afterTransactionCommit.push(() => afterTransactionCommit(event));
+				saveOptions.queryRunner.afterTransactionCommit.push(() => {
+					if (subscriber?.afterTransactionCommit) {
+						subscriber.afterTransactionCommit(event);
+					}
+				});
 			}
 			if (saveOptions?.subscriber?.afterTransactionCommit) {
-				const afterTransactionCommit = saveOptions?.subscriber.afterTransactionCommit;
-				saveOptions.queryRunner.afterTransactionCommit.push(() => afterTransactionCommit(event));
+				saveOptions.queryRunner.afterTransactionCommit.push(() => {
+					if (saveOptions?.subscriber?.afterTransactionCommit) {
+						saveOptions.subscriber.afterTransactionCommit(event);
+					}
+				});
 			}
 
 			// events related to transaction rollback
 			if (subscriber?.beforeTransactionRollback) {
-				const beforeTransactionRollback = subscriber.beforeTransactionRollback;
-				saveOptions.queryRunner.beforeTransactionRollback.push(() => beforeTransactionRollback(event));
+				saveOptions.queryRunner.beforeTransactionRollback.push(() => {
+					if (subscriber?.beforeTransactionRollback) {
+						subscriber.beforeTransactionRollback(event);
+					}
+				});
 			}
 			if (saveOptions?.subscriber?.beforeTransactionRollback) {
-				const beforeTransactionRollback = saveOptions?.subscriber.beforeTransactionRollback;
-				saveOptions.queryRunner.beforeTransactionRollback.push(() => beforeTransactionRollback(event));
+				saveOptions.queryRunner.beforeTransactionRollback.push(() => {
+					if (saveOptions?.subscriber?.beforeTransactionRollback) {
+						saveOptions?.subscriber.beforeTransactionRollback(event);
+					}
+				});
 			}
 			if (subscriber?.afterTransactionRollback) {
-				const afterTransactionRollback = subscriber.afterTransactionRollback;
-				saveOptions.queryRunner.afterTransactionRollback.push(() => afterTransactionRollback(event));
+				saveOptions.queryRunner.afterTransactionRollback.push(() => {
+					if (subscriber?.afterTransactionRollback) {
+						subscriber.afterTransactionRollback(event);
+					}
+				});
 			}
 			if (saveOptions?.subscriber?.afterTransactionRollback) {
-				const afterTransactionRollback = saveOptions?.subscriber.afterTransactionRollback;
-				saveOptions.queryRunner.afterTransactionRollback.push(() => afterTransactionRollback(event));
+				saveOptions.queryRunner.afterTransactionRollback.push(() => {
+					if (saveOptions?.subscriber?.afterTransactionRollback) {
+						saveOptions?.subscriber.afterTransactionRollback(event);
+					}
+				});
 			}
 
 		}

--- a/src/manager/entity-manager.ts
+++ b/src/manager/entity-manager.ts
@@ -189,19 +189,19 @@ export class EntityManager<T = any> {
 	}
 
 	/**
-	 * Save an object to the database
-	 * @param {EntityValues<T>} object Object to be saved in the database.
-	 * @param {SaveOptions} saveOptions Save options.
-	 * @return {Promise<T>} Object reference saved in the database.
-	 */
-	public async save(object: EntityValues<T>, saveOptions?: SaveOptions): Promise<T>;
-	/**
 	 * Save objects to the database
 	 * @param {EntityValues<T>} objects Objects to be saved in the database.
 	 * @param {SaveOptions} saveOptions Save options.
 	 * @return {Promise<T>} Objects reference saved in the database.
 	 */
 	public async save(objects: EntityValues<T>[], saveOptions?: SaveOptions): Promise<T[]>;
+	/**
+	 * Save an object to the database
+	 * @param {EntityValues<T>} object Object to be saved in the database.
+	 * @param {SaveOptions} saveOptions Save options.
+	 * @return {Promise<T>} Object reference saved in the database.
+	 */
+	public async save(object: EntityValues<T>, saveOptions?: SaveOptions): Promise<T>;
 	/**
 	 * Save an object or multiple objects to the database.
 	 * @param {EntityValues<T>} objects Objects to be saved in the database.
@@ -246,19 +246,19 @@ export class EntityManager<T = any> {
 	}
 
 	/**
-	 * Delete an object from the database.
-	 * @param {EntityValues<T>} object Object to be deleted.
-	 * @param {DeleteOptions} deleteOptions Deletion Options.
-	 * @return {Promise<boolean>} True if object has been deleted
-	 */
-	public async delete(object: EntityValues<T>, deleteOptions?: DeleteOptions): Promise<boolean>;
-	/**
 	 * Delete multiple objects from the database.
 	 * @param {EntityValues<T>[]} objects Objects to be deleted.
 	 * @param {DeleteOptions} deleteOptions Deletion Options.
 	 * @return {Promise<boolean>} True if objects have been deleted.
 	 */
 	public async delete(objects: EntityValues<T>[], deleteOptions?: DeleteOptions): Promise<boolean>;
+	/**
+	 * Delete an object from the database.
+	 * @param {EntityValues<T>} object Object to be deleted.
+	 * @param {DeleteOptions} deleteOptions Deletion Options.
+	 * @return {Promise<boolean>} True if object has been deleted
+	 */
+	public async delete(object: EntityValues<T>, deleteOptions?: DeleteOptions): Promise<boolean>;
 	/**
 	 * Delete an object or multiple objects from the database
 	 * @param {EntityValues<T> | EntityValues<T>[]} objects Object or objects to be deleted

--- a/src/manager/entity-manager.ts
+++ b/src/manager/entity-manager.ts
@@ -1,693 +1,745 @@
-import { SimpleMap } from "../common";
-import { Connection } from "../connection";
-import { ColumnMetadata, EntitySubscriberInterface, ForeignKeyMetadata, EntityMetadata } from "../metadata";
-import { DeleteQueryBuilder, InsertQueryBuilder, SelectQueryBuilder, UpdateQueryBuilder, QueryWhere, QueryResult, QueryManager } from "../query-builder";
-import { FindOptions } from "./options/find-options";
-import { QueryRelationBuilder, QueryColumnBuilder, QueryDatabaseColumnBuilder, QueryJsonAggColumnBuilder, QueryJsonColumnBuilder, QueryWhereColumnBuilder, QueryAggregateColumnBuilder } from "../query-builder";
-import { FindSelect } from "./types/find-select";
-import { EntityValues } from "./types/entity-values";
-import { SaveOptions } from "./options/save-options";
-import { StringUtils } from "../utils";
-import { OrmUtils } from "../utils";
-import { QueryRunner } from "../query-runner";
-import { ColumnMetadataNotLocatedError, DuplicateColumnInQuery, InvalidEntityPropertyValueError } from "../errors";
-import { DeleteOptions } from "./options/delete-options";
-import { CokeModel } from "./coke-model";
+import { SimpleMap } from '../common';
+import { Connection } from '../connection';
+import { ColumnMetadata, EntitySubscriberInterface, ForeignKeyMetadata, EntityMetadata } from '../metadata';
+import { DeleteQueryBuilder, InsertQueryBuilder, SelectQueryBuilder, UpdateQueryBuilder, QueryWhere, QueryManager } from '../query-builder';
+import { FindOptions } from './options/find-options';
+import { QueryRelationBuilder, QueryColumnBuilder, QueryDatabaseColumnBuilder, QueryJsonAggColumnBuilder, QueryJsonColumnBuilder, QueryWhereColumnBuilder, QueryAggregateColumnBuilder } from '../query-builder';
+import { FindSelect } from './types/find-select';
+import { EntityValues } from './types/entity-values';
+import { SaveOptions } from './options/save-options';
+import { StringUtils } from '../utils';
+import { OrmUtils } from '../utils';
+import { QueryRunner } from '../query-runner';
+import { ColumnMetadataNotLocatedError, DuplicateColumnInQuery, InvalidEntityPropertyValueError } from '../errors';
+import { DeleteOptions } from './options/delete-options';
+import { CokeModel } from './coke-model';
 
+/**
+ * Class responsible for managing an entity, performing find, save, delete and
+ * other methods.
+ */
 export class EntityManager<T = any> {
 
-   /**
-    * 
-    */
-   public get connection(): Connection {
-      return this.metadata.connection;
-   }
-
-   /**
-    * 
-    */
-   public readonly metadata: EntityMetadata;
-
-   /**
-    * 
-    * @param entityMetadata
-    */
-   constructor(entityMetadata: EntityMetadata) {
-      this.metadata = entityMetadata;
-   }
-
-   /**
-    * 
-    * @param values 
-    * @returns 
-    */
-   public create(values?: EntityValues<T>, requestingEntityColumn?: ColumnMetadata, entity?: T): T {
-
-      if (requestingEntityColumn?.relation?.createEntity) {
-         return requestingEntityColumn?.relation?.createEntity(this, entity, values);
-      }
-
-      const object: T = new (this.metadata.target)();
-      if (values) {
-         this.createCascade(object, values);
-      }
-      return object;
-
-   }
-
-   /**
-    * 
-    */
-   private createCascade(object: any, values: any): void {
-      
-      /// get the properties of the object that contains the values that will
-      /// be loaded into the object
-
-      const objectKeys = Object.keys(values);
-
-      /// get only the entity columns that are in the values object to be 
-      /// populated in the main object
-
-      const columnsMetadata: ColumnMetadata[] = Object.values(this.metadata.columns).filter(columnMetadata => objectKeys.indexOf(columnMetadata.propertyName) >= 0);
-
-      /// load the values into the main object
-      for (const columnMetadata of columnsMetadata) {
-
-         if (!columnMetadata.canPopulate) {
-            continue;
-         }
-
-         if (columnMetadata.relation) {
-
-            if (values[columnMetadata.propertyName]) {
-               const relationEntityManager: EntityManager<any> = this.connection.getEntityManager(columnMetadata.relation.referencedEntity);
-               if (columnMetadata.relation.type == 'OneToMany') {
-                  if (!Array.isArray(values[columnMetadata.propertyName])) {
-                     throw new InvalidEntityPropertyValueError(`The value of the property '${columnMetadata.propertyName}' of the entity '${this.metadata.className}' is not an array`)
-                  }
-                  object[columnMetadata.propertyName] = values[columnMetadata.propertyName].map((value: any) => relationEntityManager.create(value, columnMetadata, object));
-               } else {
-                  object[columnMetadata.propertyName] = relationEntityManager.create(values[columnMetadata.propertyName], columnMetadata, object);
-               }
-            } else {
-               object[columnMetadata.propertyName] = values[columnMetadata.propertyName];
-            }
-
-         } else {
-            object[columnMetadata.propertyName] = values[columnMetadata.propertyName];
-         }
-
-         if (columnMetadata.enum && object[columnMetadata.propertyName] != null) {
-
-            if (typeof object[columnMetadata.propertyName] == 'string') {
-               object[columnMetadata.propertyName] = columnMetadata.enum[object[columnMetadata.propertyName]];
-            }
-
-            if (!columnMetadata.enum[object[columnMetadata.propertyName]]) {
-               throw new InvalidEntityPropertyValueError(`The value of the property '${columnMetadata.propertyName}' of the entity '${this.metadata.className}' does not contain a valid value for the enumerated`);
-            }
-
-         }
-
-      }
-   }
-
-   /**
-    * 
-    * @param findOptions 
-    * @returns 
-    */
-   public async findOne(findOptions: FindOptions<T>, queryRunner?: QueryRunner, runEventAfterLoad = true): Promise<T> {
-      
-      const [result]: any = await this.find({ 
-         ...findOptions,
-         limit: 1
-      }, queryRunner, runEventAfterLoad);
-      
-      return result;
-   
-   }
-
-   /**
-    * 
-    * @param findOptions 
-    * @returns 
-    */
-   public async find(findOptions?: FindOptions<T>, queryRunner?: QueryRunner, runEventAfterLoad = true): Promise<T[]> {
-
-      /// create the query
-      const query: SelectQueryBuilder<T> = this.createSelectQuery(findOptions, 0);
-
-      /// run the query to get the result
-      const result: T[] = await query.execute(queryRunner);
-
-      if (result.length > 0) {
-
-         /// create the entity-related subscriber to run the events
-         const subscriber: EntitySubscriberInterface<T> | undefined = (runEventAfterLoad ? this.createEntitySubscriber() : undefined);
-
-         /// transform the query result into its specific classes
-         for (let i = 0; i < result.length; i++) {
-            result[i] = this.create(result[i]);
-
-            if (subscriber?.afterLoad) {
-               await subscriber.afterLoad({
-                  connection: (queryRunner?.connection ?? this.connection),
-                  queryRunner: (queryRunner instanceof QueryRunner ? queryRunner : undefined),
-                  manager: this,
-                  findOptions: findOptions,
-                  entity: result[i]
-               });
-            }
-         }
-         return result;
-
-      }
-
-      return [];
-   }
-
-   /**
-    * 
-    */
-   public async save(object: EntityValues<T>, saveOptions?: SaveOptions): Promise<T>;
-   /**
-    * 
-    */
-   public async save(objects: EntityValues<T>[], saveOptions?: SaveOptions): Promise<T[]>;
-   /**
-    * 
-    */
-   public async save(objects: EntityValues<T> | EntityValues<T>[], saveOptions?: SaveOptions): Promise<T | T[]> {
-
-      const returnArray = Array.isArray(objects)
-      if (!returnArray) {
-         objects = [objects];
-      }
-
-      let queryRunner: QueryRunner = (saveOptions?.queryRunner ?? this.connection.queryRunner);      
-      let savedObjects;
-      
-      if (queryRunner.inTransaction) {
-         savedObjects = await this.performSave((Array.isArray(objects) ? objects : [objects]), { ...saveOptions, queryRunner });
-      } else {
-         savedObjects = await queryRunner.connection.transaction((queryRunner) => this.performSave((Array.isArray(objects) ? objects : [objects]), { ...saveOptions, queryRunner }));
-      }
-
-      return (returnArray ? savedObjects : savedObjects[0]);
-      
-   }
-
-   /**
-    * 
-    * @param objectToSave 
-    * @param saveOptions 
-    * @returns 
-    */
-   private async performSave(objectToSave: EntityValues<T>[], saveOptions: SaveOptions): Promise<any[]> {
-      
-      const savedObjects: any[] = [];
-      for (let object of objectToSave) {
-         object = this.create(object);
-         savedObjects.push(await (object as CokeModel).save({ ...saveOptions, recreateObjects: false }));
-      }
-      return savedObjects;
-
-   }
-
-   /**
-    * 
-    * @param queryRunner 
-    */
-    public async delete(object: any, deleteOptions?: DeleteOptions): Promise<boolean>;
-   /**
-    *
-    * @param queryRunner 
-    */
-   public async delete(objects: any[], deleteOptions?: DeleteOptions): Promise<boolean>;
-   /**
-    * 
-    * @param queryRunner 
-    */
-   public async delete(objects: any | any[], deleteOptions?: DeleteOptions): Promise<boolean> {
-
-      if (!Array.isArray(objects)) {
-         objects = [objects];
-      }
-
-      let queryRunner: QueryRunner = (deleteOptions?.queryRunner ?? this.connection.queryRunner);
-      let deletedObjects;
-
-      if (queryRunner.inTransaction) {
-         deletedObjects = await this.performDelete((Array.isArray(objects) ? objects : [objects]), { ...deleteOptions, queryRunner });
-      } else {
-         deletedObjects = await queryRunner.connection.transaction((queryRunner) => this.performDelete((Array.isArray(objects) ? objects : [objects]), { ...deleteOptions, queryRunner }));
-      }
-
-      return (deletedObjects.length > 0);
-   }
-
-   /**
-    * 
-    * @param objectToDelete 
-    * @param queryRunner 
-    * @returns 
-    */
-   private async performDelete(objectToDelete: EntityValues<T>[], deleteOptions: DeleteOptions): Promise<any[]> {
-      
-      const deletedObjects: any[] = [];
-      for (let object of objectToDelete) {
-         object = this.create(object);
-
-         const deleted: boolean = await (object as CokeModel).delete(deleteOptions);
-         if (deleted) {
-            deletedObjects.push(object);
-         }
-
-      }
-      return deletedObjects;
-
-   }
-
-   /**
-    * 
-    * @param findOptions 
-    * @returns 
-    */
-   public createSelectQuery(findOptions?: FindOptions<T>, level?: number, relationMetadata?: ForeignKeyMetadata): SelectQueryBuilder<T> {
-
-      /// create a copy of findOptions to not modify the original and help to 
-      /// copy it with the standard data needed to find the records
-      findOptions = new FindOptions(findOptions);
-      FindOptions.loadDefaultOrderBy(this.metadata, findOptions);
-
-      /// obtain the list of columns to be consulted in the main entity (if the 
-      /// list of columns is not informed in the find options, all columns that 
-      /// are unrelated will be obtained, or that the relation is in the 
-      /// `relations` parameter).
-      ///
-      /// In the related columns, the `SelectQueryBuilder` will also be returned 
-      /// to make the` left join` in the entity and obtain the JSON of the entity 
-      /// data.
-      const queryColumns: QueryColumnBuilder<T>[] = this.loadQueryColumns(findOptions, level ?? 0);
-
-      /// extract the `SelectQueryBuilder` from the related columns to generate
-      /// the `left join` in the main entity
-      const queryJoins: QueryRelationBuilder<T>[] = this.loadQueryJoins(queryColumns);
-
-      /// if the entity has a column with 'DeletedAt' operation, a filter will be 
-      /// added to 'findOptions.where' so as not to get the deleted rows
-      const deletedAtColumnMetadata: ColumnMetadata | null = this.metadata.getDeletedAtColumn();
-      if (deletedAtColumnMetadata) {
-         
-         if (!findOptions.where) {
-            findOptions.where = {};
-         }
-
-         const deletedAtWhere: any = {};
-         deletedAtWhere[deletedAtColumnMetadata.propertyName] = { isNull: true };
-
-         if (Array.isArray(findOptions.where)) {
-         
-            findOptions.where = {
-               ...deletedAtWhere,
-               AND: findOptions.where
-            }
-            
-         } else {
-            
-            Object.assign(findOptions.where, deletedAtWhere);
-         
-         }
-      
-      }
-
-      /// create the query to get the data
-      const query: SelectQueryBuilder<T> = new SelectQueryBuilder<T>(this.connection, this.metadata)
-         .level(level ?? 0)
-         .select(queryColumns)
-         .join(queryJoins)
-         //.virtualDeletionColumn(this.entityMetadata.getDeletedAtColumn()?.name)
-         .where(findOptions.where)
-         .orderBy(findOptions.orderBy)
-         .skip(findOptions.skip)
-         .limit(findOptions.limit)
-
-      if ((level ?? 0) > 0) {
-         query.where();
-      }
-      
-      return query;
-   
-   }
-
-   /**
-    * 
-    * @returns 
-    */
-   public createInsertQuery(): InsertQueryBuilder<T> {
-      return new InsertQueryBuilder<T>(this.connection, this.metadata);
-   }
-
-   /**
-    * 
-    * @returns 
-    */
-   public createUpdateQuery() : UpdateQueryBuilder<T> {
-      const query: UpdateQueryBuilder<T> = new UpdateQueryBuilder<T>(this.connection, this.metadata)
-         //.virtualDeletionColumn(this.entityMetadata.getDeletedAtColumn()?.name);
-      return query;      
-   }
-
-   /**
-    * 
-    * @returns 
-    */
-   public createDeleteQuery(): DeleteQueryBuilder<T> {
-      const query: DeleteQueryBuilder<T> = new DeleteQueryBuilder<T>(this.connection, this.metadata)
-         //.virtualDeletionColumn(this.entityMetadata.getDeletedAtColumn()?.name);
-      return query;
-   }
-
-   /**
-    * 
-    * @param columnsToBeLoaded 
-    * @param relations 
-    * @param roles 
-    * @returns 
-    */
-   private loadQueryColumns<T>(findOptions: FindOptions<T>, level: number): QueryColumnBuilder<T>[] {
-
-      /// If there are no columns informed to be loaded, all columns of entities 
-      /// that do not have relations will be obtained, or that the relation is 
-      /// in the parameter `relations`.
-      if (!findOptions.select || findOptions.select.length == 0) 
-      {
-         findOptions.select = Object.values(this.metadata.columns)
-            .filter(column => column.canSelect && column.operation != 'DeletedIndicator' && column.operation != 'Virtual' && (!column.relation || (column.relation.eager || (findOptions.relations ?? []).indexOf(column.propertyName) >= 0)))
-            .map(column => column.propertyName);
-      }
-
-      /// initialize the array that will store the query columns
-      const queryColumns: SimpleMap<QueryColumnBuilder<T>> = new SimpleMap();
-
-      for (const columnStructure of findOptions.select) {
-
-         const columnData: [string, FindSelect] = (typeof columnStructure == 'string' ? [columnStructure, []] : columnStructure) as [string, FindSelect];         
-         const columnMetadata: ColumnMetadata = this.metadata.columns[columnData[0]];
-
-         if (!columnMetadata) {
-            throw new ColumnMetadataNotLocatedError(this.metadata.className, columnData[0]);
-         }
-
-         if (queryColumns[columnData[0]]) {
-            throw new DuplicateColumnInQuery(columnMetadata);
-         }
-
-         /// If the column has roles restrictions, it will only appear in the 
-         /// query result if the role is informed in the findOptions.roles
-         if ((columnMetadata.roles ?? []).length > 0 && columnMetadata.roles?.some((role => (findOptions.roles?.indexOf(role) ?? 0) < 0))) {
-            continue;
-         }
-
-         if (columnMetadata.relation) {
-
-            const relationAlias: string = this.connection.options.namingStrategy?.eagerJoinRelationAlias(columnMetadata) as string;
-            const relationEntityManager: EntityManager<any> =  this.connection.getEntityManager(columnMetadata.relation.referencedEntity);
-
-            if (columnMetadata.relation.type == 'OneToMany') {
-
-               const referencedColumn: ColumnMetadata = relationEntityManager.metadata.columns[columnMetadata.relation.referencedColumn];
-               const relationQuery: SelectQueryBuilder<any> = this.createChildSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level + 1);
-
-               queryColumns[columnData[0]] = new QueryDatabaseColumnBuilder({
-                  table: relationAlias,
-                  column: columnMetadata.propertyName,
-                  alias: columnMetadata.propertyName,
-                  relation: new QueryRelationBuilder<any>({
-                     type: 'left',
-                     table: relationQuery,
-                     alias: relationAlias,
-                     condition: `"${relationAlias}"."${referencedColumn.propertyName}" = "${this.metadata.className}"."${referencedColumn.relation?.referencedColumn}"`
-                  }),
-               });
-
-            } else {
-
-               const relationQuery: SelectQueryBuilder<any> = this.createParentSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level + 1);
-
-               queryColumns[columnData[0]] = new QueryDatabaseColumnBuilder({
-                  table: relationAlias,
-                  column: columnMetadata.propertyName,
-                  alias: columnMetadata.propertyName,
-                  relation: new QueryRelationBuilder<any>({
-                     type: ((findOptions.where as any ?? {})[columnMetadata.propertyName] ? 'inner' : 'left'),
-                     table: relationQuery,
-                     alias: relationAlias,
-                     condition: `"${relationAlias}"."${columnMetadata.relation.referencedColumn}" = "${this.metadata.className}"."${columnMetadata.name}"`
-                  }),
-               });
-
-            }
-
-         } else {
-
-            queryColumns[columnData[0]] = new QueryDatabaseColumnBuilder({
-               table: this.metadata.className,
-               column: columnMetadata.propertyName,
-               alias: columnMetadata.propertyName
-            });
-
-         }
-      }      
-      
-      return Object.values(queryColumns);
-   }
-
-   /**
-    * 
-    * @param columnMetadata 
-    * @param columnData 
-    * @param relationEntityManager 
-    * @param relations 
-    * @param roles 
-    * @returns 
-    */
-   private createSubquery<T>(columnMetadata: ColumnMetadata, columnData: [string, FindSelect], relationEntityManager: EntityManager<any>, findOptions: FindOptions<T>, level: number): SelectQueryBuilder<T> {
-      
-      const subqueryRelations = (findOptions.relations ?? [])
-         .filter(relation => relation.startsWith(`${columnMetadata.propertyName}.`))
-         .map(relation => relation.substring(relation.indexOf('.') + 1, relation.length));
-
-      const queryWhereColumns: QueryWhereColumnBuilder<T>[] = [];
-      if (OrmUtils.isNotEmpty(findOptions.where)) {
-
-         let subqueryWhere: any[] = [];
-         if (!Array.isArray(findOptions.where)) {
-            subqueryWhere = [findOptions.where];
-         } else {
-            subqueryWhere = findOptions.where;
-         }
-
-         for (let i = 0; i < subqueryWhere.length; i++) {
-            
-            const queryWhere: any = subqueryWhere[i];
-            const whereValue: any = queryWhere[columnMetadata.propertyName];
-            const wherekeys = (OrmUtils.isNotEmpty(whereValue) ? Object.keys(whereValue) : []);
-
-            if (wherekeys.length > 0 && (wherekeys.length != 1 || !QueryManager.operatorsConstructor[wherekeys[0]])) {
-            
-               const sha1Where: string = StringUtils.sha1(JSON.stringify(queryWhere[columnMetadata.propertyName]));
-               if (queryWhereColumns.filter(column => column.alias == sha1Where).length == 0) { 
-
-                  queryWhereColumns.push(new QueryWhereColumnBuilder({
-                     where: whereValue,
-                     alias: sha1Where
-                  }))
-
-               }
-
-               subqueryWhere[i][`${columnMetadata.propertyName}_${columnMetadata.relation?.referencedEntity}.${sha1Where}`] = { equal: true };
-               delete queryWhere[columnMetadata.propertyName];
-            
-            }
-
-         }
-
-      }
-
-      const subqueryOrderBy: any = (findOptions.orderBy as any ?? {})[columnMetadata.propertyName];
-
-      const relationQuery: SelectQueryBuilder<T> = relationEntityManager.createSelectQuery({
-         select: (columnData.length > 1 ? columnData[1] as [string, FindSelect] : []),
-         relations: subqueryRelations,
-         where: queryWhereColumns.map(queryWhereColumn => queryWhereColumn.where) as any,
-         orderBy: subqueryOrderBy,
-         roles: findOptions.roles
-      }, level, columnMetadata.relation);
-
-      if (OrmUtils.isNotEmpty(queryWhereColumns)) {
-         relationQuery.select([
-            ...(relationQuery.queryManager.columns ?? []),
-            ...queryWhereColumns.map(queryWhereColumn => new QueryWhereColumnBuilder({
-               where: queryWhereColumn.where,
-               alias: queryWhereColumn.alias
-            }))
-         ]);
-      }
-
-      return relationQuery;
-   }
-
-   /**
-    * 
-    * @param columnMetadata 
-    * @param columnData 
-    * @param relationEntityManager 
-    * @param relations 
-    * @param roles 
-    * @returns 
-    */
-   private createChildSubquery<T>(columnMetadata: ColumnMetadata, columnData: [string, FindSelect], relationEntityManager: EntityManager<any>, findOptions: FindOptions<T>, level: number): SelectQueryBuilder<T> {
-      const relationQuery: SelectQueryBuilder<T> = this.createSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level);
-
-      relationQuery.select([
-         new QueryDatabaseColumnBuilder({
-            table: relationEntityManager.metadata.className,
-            column: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName as string,
-            alias: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName as string
-         }),
-         new QueryJsonAggColumnBuilder({
-            jsonColumn: new QueryJsonColumnBuilder({
-               jsonColumns: (relationQuery.queryManager.columns as QueryColumnBuilder<any>[]).filter((column) => !(column instanceof QueryWhereColumnBuilder)),
-               alias: columnMetadata.propertyName
-            }),
-            orderBy: relationQuery.queryManager.orderBy,
-            alias: columnMetadata.propertyName
-         }),
-         ...(relationQuery.queryManager.columns as QueryColumnBuilder<any>[])
-            .filter((column) => column instanceof QueryWhereColumnBuilder)
-            .map((column) => new QueryAggregateColumnBuilder({
-               type: 'max',
-               column: new QueryWhereColumnBuilder({
-                  ...column as any,
-                  cast: 'int'
-               }),
-               cast: 'boolean',
-               alias: column.alias
-            }))
-      ]);
-
-      relationQuery.groupBy(new QueryDatabaseColumnBuilder({
-         table: relationEntityManager.metadata.className,
-         column: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName,
-         alias: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName
-      }));
-
-      /// remove o order by pois ele foi adicionado dentro do SelectJsonAgg
-      relationQuery.orderBy();
-
-      return relationQuery;
-   }
-
-   /**
-    * 
-    * @param columnMetadata 
-    * @param columnData 
-    * @param relationEntityManager 
-    * @param relations 
-    * @param roles 
-    * @returns 
-    */
-   private createParentSubquery<T>(columnMetadata: ColumnMetadata, columnData: [string, FindSelect], relationEntityManager: EntityManager<any>, findOptions: FindOptions<T>, level: number): SelectQueryBuilder<T> {
-      const relationQuery: SelectQueryBuilder<T> = this.createSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level);
-
-      relationQuery.select([
-         new QueryDatabaseColumnBuilder({
-            table: relationEntityManager.metadata.className,
-            column: columnMetadata.relation?.referencedColumn as string,
-            alias: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName
-         }),
-         new QueryJsonColumnBuilder({
-            jsonColumns: (relationQuery.queryManager.columns as QueryColumnBuilder<any>[]).filter((column) => !(column instanceof QueryWhereColumnBuilder)),
-            alias: columnMetadata.propertyName
-         }),
-         ...(relationQuery.queryManager.columns as QueryColumnBuilder<any>[])
-            .filter((column) => column instanceof QueryWhereColumnBuilder)
-      ]);
-
-      return relationQuery;
-   }
-
-   /**
-    * 
-    * @param queryColumns 
-    * @returns 
-    */
-   private loadQueryJoins(queryColumns: QueryColumnBuilder<T>[]): QueryRelationBuilder<T>[] {
-
-      return queryColumns
-         .filter((queryColumn) => queryColumn instanceof QueryDatabaseColumnBuilder && queryColumn.relation)
-         .map((queryColumn) => {
-
-            return new QueryRelationBuilder<T>({
-               type: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.type,
-               table: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.table,
-               alias: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.alias,
-               condition: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.condition
-            } as any)
-
-         });
-
-   }
-
-   /**
-    * 
-    * @param object 
-    * @returns 
-    */
-   public createWhereFromColumns(values: any, columns: string[]): QueryWhere<T> | undefined {
-
-      const valuesKeys: string[] = Object.keys(values);
-
-      if (valuesKeys.length == 0) {
-         return undefined;
-      }
-
-      const where: QueryWhere<any> = {};
-      for (const column of columns) {
-
-         if (valuesKeys.indexOf(column) < 0) {
-            return undefined;
-         }
-
-         const columnMetadata: ColumnMetadata = this.metadata.columns[column];
-         if (!columnMetadata) {
-            throw Error('Coluna inválida para criação do Where')
-         }
-
-         let value: any = (values as any)[column];
-         if (value instanceof Object && columnMetadata.relation && columnMetadata.relation.type != 'OneToMany') {
-            value = value[columnMetadata.relation.referencedColumn];
-         }
-
-         where[columnMetadata.name as string] = (value == null 
-            ? { isNull: true }
-            : value);
-
-      }
-
-      return where;
-
-   }
-
-   /**
-    * Create the entity-related subscriber to run the events
-    */
-   public createEntitySubscriber(): EntitySubscriberInterface<T> | undefined {
-      if (this.metadata.subscriber) {
-         return new (this.metadata.subscriber)();
-      }
-      return undefined;
-   }
+	/**
+	 * Manager connection.
+	 */
+	public get connection(): Connection {
+		return this.metadata.connection;
+	}
+
+	/**
+	 * Managed entity metadata
+	 */
+	public readonly metadata: EntityMetadata;
+
+	/**
+	 * Default class constructor.
+	 * @param {EntityMetadata} entityMetadata Entity to be managed.
+	 */
+	constructor(entityMetadata: EntityMetadata) {
+		this.metadata = entityMetadata;
+	}
+
+	/**
+	 * Creates the instance of the managed entity type class
+	 * @param {EntityValues<T>} values Entity Values
+	 * @param {ColumnMetadata} requestingEntityColumn Column of the entity that
+	 * is requesting the creation of the class, it is only used internally by
+	 * the 'create' method to know if the column has a relationship and also the
+	 * property 'createEntity', indicating that the creation of the class will
+	 * be customized by the user.
+	 * @param {T} entity Instance of the class that is requesting the creation
+	 * of this entity's class.
+	 * @return {T} Instance of this managed class.
+	 */
+	public create(values?: EntityValues<T>, requestingEntityColumn?: ColumnMetadata, entity?: T): T {
+
+		if (requestingEntityColumn?.relation?.createEntity) {
+			return requestingEntityColumn?.relation?.createEntity(this, entity, values);
+		}
+
+		const object: T = new (this.metadata.target)();
+		if (values) {
+			this.populate(object, values);
+		}
+		return object;
+
+	}
+
+	/**
+	 * Populate the created class with the values passed by parameter, if the
+	 * field to be populated is a relation, then the cascading relation classes
+	 * will also be created.
+	 * @param {any} instance Instance of the class that will be populated.
+	 * @param {any} values Values that will be informed in the class
+	 */
+	private populate(instance: any, values: any): void {
+
+		// get the properties of the object that contains the values that will
+		// be loaded into the object
+
+		const objectKeys = Object.keys(values);
+
+		// get only the entity columns that are in the values object to be
+		// populated in the main object
+
+		const columnsMetadata: ColumnMetadata[] = Object.values(this.metadata.columns).filter((columnMetadata) => objectKeys.indexOf(columnMetadata.propertyName) >= 0);
+
+		// load the values into the main object
+		for (const columnMetadata of columnsMetadata) {
+
+			if (!columnMetadata.canPopulate) {
+				continue;
+			}
+
+			if (columnMetadata.relation) {
+
+				if (values[columnMetadata.propertyName]) {
+					const relationEntityManager: EntityManager<any> = this.connection.getEntityManager(columnMetadata.relation.referencedEntity);
+					if (columnMetadata.relation.type == 'OneToMany') {
+						if (!Array.isArray(values[columnMetadata.propertyName])) {
+							throw new InvalidEntityPropertyValueError(`The value of the property '${columnMetadata.propertyName}' of the entity '${this.metadata.className}' is not an array`);
+						}
+						instance[columnMetadata.propertyName] = values[columnMetadata.propertyName].map((value: any) => relationEntityManager.create(value, columnMetadata, instance));
+					} else {
+						instance[columnMetadata.propertyName] = relationEntityManager.create(values[columnMetadata.propertyName], columnMetadata, instance);
+					}
+				} else {
+					instance[columnMetadata.propertyName] = values[columnMetadata.propertyName];
+				}
+
+			} else {
+				instance[columnMetadata.propertyName] = values[columnMetadata.propertyName];
+			}
+
+			if (columnMetadata.enum && instance[columnMetadata.propertyName] != null) {
+
+				if (typeof instance[columnMetadata.propertyName] == 'string') {
+					instance[columnMetadata.propertyName] = columnMetadata.enum[instance[columnMetadata.propertyName]];
+				}
+
+				if (!columnMetadata.enum[instance[columnMetadata.propertyName]]) {
+					throw new InvalidEntityPropertyValueError(`The value of the property '${columnMetadata.propertyName}' of the entity '${this.metadata.className}' does not contain a valid value for the enumerated`);
+				}
+
+			}
+
+		}
+	}
+
+	/**
+	 * Query and return the first record that matches the query criteria.
+	 * @param {FindOptions<T>} findOptions Find Options.
+	 * @param {QueryRunner} queryRunner Query Runner used to perform the query.
+	 * @param {boolean} runEventAfterLoad Indicates whether the load events of
+	 * subscribers can be performed.
+	 * @return {Promise<T>} First record found in database.
+	 */
+	public async findOne(findOptions: FindOptions<T>, queryRunner?: QueryRunner, runEventAfterLoad: boolean = true): Promise<T> {
+
+		const [result]: any = await this.find({
+			...findOptions,
+			limit: 1,
+		}, queryRunner, runEventAfterLoad);
+
+		return result;
+
+	}
+
+	/**
+	 * Query and return the records that matches the query criteria.
+	 * @param {FindOptions<T>} findOptions Find Options.
+	 * @param {QueryRunner} queryRunner Query Runner used to perform the query.
+	 * @return {Promise<T[]>} Records found in the database.
+	 * @param {boolean} runEventAfterLoad Indicates whether the load events of
+	 * subscribers can be performed.
+	 */
+	public async find(findOptions?: FindOptions<T>, queryRunner?: QueryRunner, runEventAfterLoad = true): Promise<T[]> {
+
+		// create the query
+		const query: SelectQueryBuilder<T> = this.createSelectQuery(findOptions, 0);
+
+		// run the query to get the result
+		const result: T[] = await query.execute(queryRunner);
+
+		if (result.length > 0) {
+
+			// create the entity-related subscriber to run the events
+			const subscriber: EntitySubscriberInterface<T> | undefined = (runEventAfterLoad ? this.createEntitySubscriber() : undefined);
+
+			// transform the query result into its specific classes
+			for (let i = 0; i < result.length; i++) {
+				result[i] = this.create(result[i]);
+
+				if (subscriber?.afterLoad) {
+					await subscriber.afterLoad({
+						connection: (queryRunner?.connection ?? this.connection),
+						queryRunner: (queryRunner instanceof QueryRunner ? queryRunner : undefined),
+						manager: this,
+						findOptions: findOptions,
+						entity: result[i],
+					});
+				}
+			}
+			return result;
+
+		}
+
+		return [];
+	}
+
+	/**
+	 * Save an object to the database
+	 * @param {EntityValues<T>} object Object to be saved in the database.
+	 * @param {SaveOptions} saveOptions Save options.
+	 * @return {Promise<T>} Object reference saved in the database.
+	 */
+	public async save(object: EntityValues<T>, saveOptions?: SaveOptions): Promise<T>;
+	/**
+	 * Save objects to the database
+	 * @param {EntityValues<T>} objects Objects to be saved in the database.
+	 * @param {SaveOptions} saveOptions Save options.
+	 * @return {Promise<T>} Objects reference saved in the database.
+	 */
+	public async save(objects: EntityValues<T>[], saveOptions?: SaveOptions): Promise<T[]>;
+	/**
+	 * Save an object or multiple objects to the database.
+	 * @param {EntityValues<T>} objects Objects to be saved in the database.
+	 * @param {SaveOptions} saveOptions Save options.
+	 * @return {Promise<T>} Object or objects reference saved in the database.
+	 */
+	public async save(objects: EntityValues<T> | EntityValues<T>[], saveOptions?: SaveOptions): Promise<T | T[]> {
+
+		const returnArray = Array.isArray(objects);
+		if (!returnArray) {
+			objects = [objects];
+		}
+
+		const queryRunner: QueryRunner = (saveOptions?.queryRunner ?? this.connection.queryRunner);
+		let savedObjects;
+
+		if (queryRunner.inTransaction) {
+			savedObjects = await this.performSave((Array.isArray(objects) ? objects : [objects]), { ...saveOptions, queryRunner });
+		} else {
+			savedObjects = await queryRunner.connection.transaction((queryRunner) => this.performSave((Array.isArray(objects) ? objects : [objects]), { ...saveOptions, queryRunner }));
+		}
+
+		return (returnArray ? savedObjects : savedObjects[0]);
+
+	}
+
+	/**
+	 * Save multiple objects to the database.
+	 * @param {EntityValues<T>[]} objectToSave Objects to be saved in the database.
+	 * @param {SaveOptions} saveOptions Save options.
+	 * @return {Promise<any[]>} Reference of objects saved in the database.
+	 */
+	private async performSave(objectToSave: EntityValues<T>[], saveOptions: SaveOptions): Promise<any[]> {
+
+		const savedObjects: any[] = [];
+		for (let object of objectToSave) {
+			object = this.create(object);
+			savedObjects.push(await (object as CokeModel).save({ ...saveOptions, recreateObjects: false }));
+		}
+		return savedObjects;
+
+	}
+
+	/**
+	 * Delete an object from the database.
+	 * @param {EntityValues<T>} object Object to be deleted.
+	 * @param {DeleteOptions} deleteOptions Deletion Options.
+	 * @return {Promise<boolean>} True if object has been deleted
+	 */
+	public async delete(object: EntityValues<T>, deleteOptions?: DeleteOptions): Promise<boolean>;
+	/**
+	 * Delete multiple objects from the database.
+	 * @param {EntityValues<T>[]} objects Objects to be deleted.
+	 * @param {DeleteOptions} deleteOptions Deletion Options.
+	 * @return {Promise<boolean>} True if objects have been deleted.
+	 */
+	public async delete(objects: EntityValues<T>[], deleteOptions?: DeleteOptions): Promise<boolean>;
+	/**
+	 * Delete an object or multiple objects from the database
+	 * @param {EntityValues<T> | EntityValues<T>[]} objects Object or objects to be deleted
+	 * @param {DeleteOptions} deleteOptions Deletion Options.
+	 * @return {Promise<boolean>} True if objects have been deleted.
+	 */
+	public async delete(objects: EntityValues<T> | EntityValues<T>[], deleteOptions?: DeleteOptions): Promise<boolean> {
+
+		if (!Array.isArray(objects)) {
+			objects = [objects];
+		}
+
+		const queryRunner: QueryRunner = (deleteOptions?.queryRunner ?? this.connection.queryRunner);
+
+		if (queryRunner.inTransaction) {
+			return await this.performDelete((Array.isArray(objects) ? objects : [objects]), { ...deleteOptions, queryRunner });
+		} else {
+			return await queryRunner.connection.transaction((queryRunner) => this.performDelete((Array.isArray(objects) ? objects : [objects]), { ...deleteOptions, queryRunner }));
+		}
+	}
+
+	/**
+	 * Delete multiple objects from the database
+	 * @param {EntityValues<T>[]} objectToDelete Object or objects to be deleted.
+	 * @param {DeleteOptions} deleteOptions Deletion Options.
+	 * @return {Promise<boolean>} True if objects have been deleted.
+	 */
+	private async performDelete(objectToDelete: EntityValues<T>[], deleteOptions: DeleteOptions): Promise<boolean> {
+
+		const deletedObjects: any[] = [];
+		for (let object of objectToDelete) {
+			object = this.create(object);
+
+			const deleted: boolean = await (object as CokeModel).delete(deleteOptions);
+			if (deleted) {
+				deletedObjects.push(object);
+			}
+
+		}
+		return (deletedObjects.length > 0);
+
+	}
+
+	/**
+	 * Create a query builder based on query options.
+	 * @param {FindOptions<T>} findOptions Find Options
+	 * @param {number} level Query level in table relationship hierarchy.
+	 * @param {ForeignKeyMetadata} relationMetadata Relation Table Manager.
+	 * @return {SelectQueryBuilder<T>} Query Builder Reference.
+	 */
+	public createSelectQuery(findOptions?: FindOptions<T>, level?: number, relationMetadata?: ForeignKeyMetadata): SelectQueryBuilder<T> {
+
+		// create a copy of findOptions to not modify the original and help to
+		// copy it with the standard data needed to find the records
+		findOptions = new FindOptions(findOptions);
+		FindOptions.loadDefaultOrderBy(this.metadata, findOptions);
+
+		// obtain the list of columns to be consulted in the main entity (if the
+		// list of columns is not informed in the find options, all columns that
+		// are unrelated will be obtained, or that the relation is in the
+		// `relations` parameter).
+		//
+		// In the related columns, the `SelectQueryBuilder` will also be returned
+		// to make the` left join` in the entity and obtain the JSON of the entity
+		// data.
+		const queryColumns: QueryColumnBuilder<T>[] = this.loadQueryColumns(findOptions, level ?? 0);
+
+		// extract the `SelectQueryBuilder` from the related columns to generate
+		// the `left join` in the main entity
+		const queryJoins: QueryRelationBuilder<T>[] = this.loadQueryJoins(queryColumns);
+
+		// if the entity has a column with 'DeletedAt' operation, a filter will be
+		// added to 'findOptions.where' so as not to get the deleted rows
+		const deletedAtColumnMetadata: ColumnMetadata | null = this.metadata.getDeletedAtColumn();
+		if (deletedAtColumnMetadata) {
+
+			if (!findOptions.where) {
+				findOptions.where = {};
+			}
+
+			const deletedAtWhere: any = {};
+			deletedAtWhere[deletedAtColumnMetadata.propertyName] = { isNull: true };
+
+			if (Array.isArray(findOptions.where)) {
+
+				findOptions.where = {
+					...deletedAtWhere,
+					AND: findOptions.where,
+				};
+
+			} else {
+
+				Object.assign(findOptions.where, deletedAtWhere);
+
+			}
+
+		}
+
+		// create the query to get the data
+		const query: SelectQueryBuilder<T> = new SelectQueryBuilder<T>(this.connection, this.metadata)
+			.level(level ?? 0)
+			.select(queryColumns)
+			.join(queryJoins)
+			// .virtualDeletionColumn(this.entityMetadata.getDeletedAtColumn()?.name)
+			.where(findOptions.where)
+			.orderBy(findOptions.orderBy)
+			.skip(findOptions.skip)
+			.limit(findOptions.limit);
+
+		if ((level ?? 0) > 0) {
+			query.where();
+		}
+
+		return query;
+
+	}
+
+	/**
+	 * Create a query builder to insert an object into the database.
+	 * @return {InsertQueryBuilder<T>} Query Builder Reference.
+	 */
+	public createInsertQuery(): InsertQueryBuilder<T> {
+		return new InsertQueryBuilder<T>(this.connection, this.metadata);
+	}
+
+	/**
+	 * Create a query builder to updatae an object into the database.
+	 * @return {UpdateQueryBuilder<T>} Query Builder Reference.
+	 */
+	public createUpdateQuery() : UpdateQueryBuilder<T> {
+		const query: UpdateQueryBuilder<T> = new UpdateQueryBuilder<T>(this.connection, this.metadata);
+		// .virtualDeletionColumn(this.entityMetadata.getDeletedAtColumn()?.name);
+		return query;
+	}
+
+	/**
+	 * Create a query builder to delete an object from the database.
+	 * @return {DeleteQueryBuilder<T>} Query Builder Reference.
+	 */
+	public createDeleteQuery(): DeleteQueryBuilder<T> {
+		const query: DeleteQueryBuilder<T> = new DeleteQueryBuilder<T>(this.connection, this.metadata);
+		// .virtualDeletionColumn(this.entityMetadata.getDeletedAtColumn()?.name);
+		return query;
+	}
+
+	/**
+	 * Load the columns that will be used in the query builder
+	 * @param {FindOptions<T>} findOptions Find Options.
+	 * @param {number} level Query level in table relationship hierarchy.
+	 * @return {QueryColumnBuilder<T>[]} Columns loaded.
+	 */
+	private loadQueryColumns<T>(findOptions: FindOptions<T>, level: number): QueryColumnBuilder<T>[] {
+
+		// If there are no columns informed to be loaded, all columns of entities
+		// that do not have relations will be obtained, or that the relation is
+		// in the parameter `relations`.
+		if (!findOptions.select || findOptions.select.length == 0) {
+			findOptions.select = Object.values(this.metadata.columns)
+				.filter((column) => column.canSelect && column.operation != 'DeletedIndicator' && column.operation != 'Virtual' && (!column.relation || (column.relation.eager || (findOptions.relations ?? []).indexOf(column.propertyName) >= 0)))
+				.map((column) => column.propertyName);
+		}
+
+		// initialize the array that will store the query columns
+		const queryColumns: SimpleMap<QueryColumnBuilder<T>> = new SimpleMap();
+
+		for (const columnStructure of findOptions.select) {
+
+			const columnData: [string, FindSelect] = (typeof columnStructure == 'string' ? [columnStructure, []] : columnStructure) as [string, FindSelect];
+			const columnMetadata: ColumnMetadata = this.metadata.columns[columnData[0]];
+
+			if (!columnMetadata) {
+				throw new ColumnMetadataNotLocatedError(this.metadata.className, columnData[0]);
+			}
+
+			if (queryColumns[columnData[0]]) {
+				throw new DuplicateColumnInQuery(columnMetadata);
+			}
+
+			// If the column has roles restrictions, it will only appear in the
+			// query result if the role is informed in the findOptions.roles
+			if ((columnMetadata.roles ?? []).length > 0 && columnMetadata.roles?.some(((role) => (findOptions.roles?.indexOf(role) ?? 0) < 0))) {
+				continue;
+			}
+
+			if (columnMetadata.relation) {
+
+				const relationAlias: string = this.connection.options.namingStrategy?.eagerJoinRelationAlias(columnMetadata) as string;
+				const relationEntityManager: EntityManager<any> = this.connection.getEntityManager(columnMetadata.relation.referencedEntity);
+
+				if (columnMetadata.relation.type == 'OneToMany') {
+
+					const referencedColumn: ColumnMetadata = relationEntityManager.metadata.columns[columnMetadata.relation.referencedColumn];
+					const relationQuery: SelectQueryBuilder<any> = this.createChildSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level + 1);
+
+					queryColumns[columnData[0]] = new QueryDatabaseColumnBuilder({
+						table: relationAlias,
+						column: columnMetadata.propertyName,
+						alias: columnMetadata.propertyName,
+						relation: new QueryRelationBuilder<any>({
+							type: 'left',
+							table: relationQuery,
+							alias: relationAlias,
+							condition: `"${relationAlias}"."${referencedColumn.propertyName}" = "${this.metadata.className}"."${referencedColumn.relation?.referencedColumn}"`,
+						}),
+					});
+
+				} else {
+
+					const relationQuery: SelectQueryBuilder<any> = this.createParentSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level + 1);
+
+					queryColumns[columnData[0]] = new QueryDatabaseColumnBuilder({
+						table: relationAlias,
+						column: columnMetadata.propertyName,
+						alias: columnMetadata.propertyName,
+						relation: new QueryRelationBuilder<any>({
+							type: ((findOptions.where as any ?? {})[columnMetadata.propertyName] ? 'inner' : 'left'),
+							table: relationQuery,
+							alias: relationAlias,
+							condition: `"${relationAlias}"."${columnMetadata.relation.referencedColumn}" = "${this.metadata.className}"."${columnMetadata.name}"`,
+						}),
+					});
+
+				}
+
+			} else {
+
+				queryColumns[columnData[0]] = new QueryDatabaseColumnBuilder({
+					table: this.metadata.className,
+					column: columnMetadata.propertyName,
+					alias: columnMetadata.propertyName,
+				});
+
+			}
+		}
+
+		return Object.values(queryColumns);
+	}
+
+	/**
+	 * Create a subquery, used in the 'createChildSubquery' and
+	 * 'createParentSubquery' method to create queries from related tables.
+	 * @param {ColumnMetadata} columnMetadata Main table column corresponding
+	 * to the relation to be loaded.
+	 * @param {[string, FindSelect]} columnData Fields to be loaded from the
+	 * list, if not informed, all fields available for consultation will be
+	 * loaded.
+	 * @param {EntityManager} relationEntityManager Relation Table Manager.
+	 * @param {FindOptions<T>} findOptions Find Options
+	 * @param {number} level Query level in table relationship hierarchy.
+	 * @return {SelectQueryBuilder<T>} Relationship Related Query Builder.
+	 */
+	private createSubquery<T>(columnMetadata: ColumnMetadata, columnData: [string, FindSelect], relationEntityManager: EntityManager, findOptions: FindOptions<T>, level: number): SelectQueryBuilder<T> {
+
+		const subqueryRelations = (findOptions.relations ?? [])
+			.filter((relation) => relation.startsWith(`${columnMetadata.propertyName}.`))
+			.map((relation) => relation.substring(relation.indexOf('.') + 1, relation.length));
+
+		const queryWhereColumns: QueryWhereColumnBuilder<T>[] = [];
+		if (OrmUtils.isNotEmpty(findOptions.where)) {
+
+			let subqueryWhere: any[] = [];
+			if (!Array.isArray(findOptions.where)) {
+				subqueryWhere = [findOptions.where];
+			} else {
+				subqueryWhere = findOptions.where;
+			}
+
+			for (let i = 0; i < subqueryWhere.length; i++) {
+
+				const queryWhere: any = subqueryWhere[i];
+				const whereValue: any = queryWhere[columnMetadata.propertyName];
+				const wherekeys = (OrmUtils.isNotEmpty(whereValue) ? Object.keys(whereValue) : []);
+
+				if (wherekeys.length > 0 && (wherekeys.length != 1 || !QueryManager.operatorsConstructor[wherekeys[0]])) {
+
+					const sha1Where: string = StringUtils.sha1(JSON.stringify(queryWhere[columnMetadata.propertyName]));
+					if (queryWhereColumns.filter((column) => column.alias == sha1Where).length == 0) {
+
+						queryWhereColumns.push(new QueryWhereColumnBuilder({
+							where: whereValue,
+							alias: sha1Where,
+						}));
+
+					}
+
+					subqueryWhere[i][`${columnMetadata.propertyName}_${columnMetadata.relation?.referencedEntity}.${sha1Where}`] = { equal: true };
+					delete queryWhere[columnMetadata.propertyName];
+
+				}
+
+			}
+
+		}
+
+		const subqueryOrderBy: any = (findOptions.orderBy as any ?? {})[columnMetadata.propertyName];
+
+		const relationQuery: SelectQueryBuilder<T> = relationEntityManager.createSelectQuery({
+			select: (columnData.length > 1 ? columnData[1] as [string, FindSelect] : []),
+			relations: subqueryRelations,
+			where: queryWhereColumns.map((queryWhereColumn) => queryWhereColumn.where) as any,
+			orderBy: subqueryOrderBy,
+			roles: findOptions.roles,
+		}, level, columnMetadata.relation);
+
+		if (OrmUtils.isNotEmpty(queryWhereColumns)) {
+			relationQuery.select([
+				...(relationQuery.queryManager.columns ?? []),
+				...queryWhereColumns.map((queryWhereColumn) => new QueryWhereColumnBuilder({
+					where: queryWhereColumn.where,
+					alias: queryWhereColumn.alias,
+				})),
+			]);
+		}
+
+		return relationQuery;
+	}
+
+	/**
+	 * Create a subquery, used by the 'createSelectQuery' method for relations
+	 * of type 'OneToMany'.
+	 * @param {ColumnMetadata} columnMetadata Main table column corresponding
+	 * to the relation to be loaded.
+	 * @param {[string, FindSelect]} columnData Fields to be loaded from the
+	 * list, if not informed, all fields available for consultation will be
+	 * loaded.
+	 * @param {EntityManager} relationEntityManager Relation Table Manager.
+	 * @param {FindOptions<T>} findOptions Find Options
+	 * @param {number} level Query level in table relationship hierarchy.
+	 * @return {SelectQueryBuilder<T>} Relationship Related Query Builder.
+	 */
+	private createChildSubquery<T>(columnMetadata: ColumnMetadata, columnData: [string, FindSelect], relationEntityManager: EntityManager, findOptions: FindOptions<T>, level: number): SelectQueryBuilder<T> {
+		const relationQuery: SelectQueryBuilder<T> = this.createSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level);
+
+		relationQuery.select([
+			new QueryDatabaseColumnBuilder({
+				table: relationEntityManager.metadata.className,
+				column: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName as string,
+				alias: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName as string,
+			}),
+			new QueryJsonAggColumnBuilder({
+				jsonColumn: new QueryJsonColumnBuilder({
+					jsonColumns: (relationQuery.queryManager.columns as QueryColumnBuilder<any>[]).filter((column) => !(column instanceof QueryWhereColumnBuilder)),
+					alias: columnMetadata.propertyName,
+				}),
+				orderBy: relationQuery.queryManager.orderBy,
+				alias: columnMetadata.propertyName,
+			}),
+			...(relationQuery.queryManager.columns as QueryColumnBuilder<any>[])
+				.filter((column) => column instanceof QueryWhereColumnBuilder)
+				.map((column) => new QueryAggregateColumnBuilder({
+					type: 'max',
+					column: new QueryWhereColumnBuilder({
+						...column as any,
+						cast: 'int',
+					}),
+					cast: 'boolean',
+					alias: column.alias,
+				})),
+		]);
+
+		relationQuery.groupBy(new QueryDatabaseColumnBuilder({
+			table: relationEntityManager.metadata.className,
+			column: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName,
+			alias: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName,
+		}));
+
+		// remove o order by pois ele foi adicionado dentro do SelectJsonAgg
+		relationQuery.orderBy();
+
+		return relationQuery;
+	}
+
+	/**
+	 * Create a subquery, used by the 'createSelectQuery' method for relations
+	 * of type 'OneToOne' and 'ManyToOne'.
+	 * @param {ColumnMetadata} columnMetadata Main table column corresponding
+	 * to the relation to be loaded.
+	 * @param {[string, FindSelect]} columnData Fields to be loaded from the
+	 * list, if not informed, all fields available for consultation will be
+	 * loaded.
+	 * @param {EntityManager} relationEntityManager Relation Table Manager.
+	 * @param {FindOptions<T>} findOptions Find Options
+	 * @param {number} level Query level in table relationship hierarchy.
+	 * @return {SelectQueryBuilder<T>} Relationship Related Query Builder.
+	 */
+	private createParentSubquery<T>(columnMetadata: ColumnMetadata, columnData: [string, FindSelect], relationEntityManager: EntityManager, findOptions: FindOptions<T>, level: number): SelectQueryBuilder<T> {
+		const relationQuery: SelectQueryBuilder<T> = this.createSubquery(columnMetadata, columnData, relationEntityManager, findOptions, level);
+
+		relationQuery.select([
+			new QueryDatabaseColumnBuilder({
+				table: relationEntityManager.metadata.className,
+				column: columnMetadata.relation?.referencedColumn as string,
+				alias: relationEntityManager.metadata.columns[columnMetadata?.relation?.referencedColumn as string].propertyName,
+			}),
+			new QueryJsonColumnBuilder({
+				jsonColumns: (relationQuery.queryManager.columns as QueryColumnBuilder<any>[]).filter((column) => !(column instanceof QueryWhereColumnBuilder)),
+				alias: columnMetadata.propertyName,
+			}),
+			...(relationQuery.queryManager.columns as QueryColumnBuilder<any>[])
+				.filter((column) => column instanceof QueryWhereColumnBuilder),
+		]);
+
+		return relationQuery;
+	}
+
+	/**
+	 * Create joins for related tables based on what you enter in the find
+	 * options.
+	 * @param {QueryColumnBuilder<T>[]} queryColumns Relationship columns for
+	 * union builds. Only fields unions of type 'QueryDatabaseColumnBuilder'
+	 * and that are related will be created.
+	 * @return {QueryRelationBuilder<T>[]} Relations to be inserted in
+	 * 'SelectQueryBuilder'.
+	 */
+	private loadQueryJoins(queryColumns: QueryColumnBuilder<T>[]): QueryRelationBuilder<T>[] {
+
+		return queryColumns
+			.filter((queryColumn) => queryColumn instanceof QueryDatabaseColumnBuilder && queryColumn.relation)
+			.map((queryColumn) => {
+
+				return new QueryRelationBuilder<T>({
+					type: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.type,
+					table: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.table,
+					alias: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.alias,
+					condition: (queryColumn as QueryDatabaseColumnBuilder<T>).relation?.condition,
+				} as any);
+
+			});
+
+	}
+
+	/**
+	 * Create the 'where' condition to be used in query builders using the
+	 * values passed by parameter.
+	 * @param {any} values Object containing the values to be used in the
+	 * query.
+	 * @param {string[]} columns Columns that will be used to mount the
+	 * condition.
+	 * @return {QueryWhere<T>} 'where' condition to be used for queries.
+	 */
+	public createWhereFromColumns(values: any, columns: string[]): QueryWhere<T> | undefined {
+
+		const valuesKeys: string[] = Object.keys(values);
+
+		if (valuesKeys.length == 0) {
+			return undefined;
+		}
+
+		const where: QueryWhere<any> = {};
+		for (const column of columns) {
+
+			if (valuesKeys.indexOf(column) < 0) {
+				return undefined;
+			}
+
+			const columnMetadata: ColumnMetadata = this.metadata.columns[column];
+			if (!columnMetadata) {
+				throw Error('Coluna inválida para criação do Where');
+			}
+
+			let value: any = (values as any)[column];
+			if (value instanceof Object && columnMetadata.relation && columnMetadata.relation.type != 'OneToMany') {
+				value = value[columnMetadata.relation.referencedColumn];
+			}
+
+			where[columnMetadata.name as string] = (value == null ? { isNull: true } : value);
+
+		}
+
+		return where;
+
+	}
+
+	/**
+	 * Create the entity-related subscriber to run the events.
+	 * @return {EntitySubscriberInterface<T>} Subscriber instance.
+	 */
+	public createEntitySubscriber(): EntitySubscriberInterface<T> | undefined {
+		if (this.metadata.subscriber) {
+			return new (this.metadata.subscriber)();
+		}
+		return undefined;
+	}
 }

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -1,17 +1,17 @@
-import { CokeModel } from "./coke-model";
-import { FindOptions } from "./options/find-options";
-import { SaveOptions } from "./options/save-options";
-import { EntityManager } from "./entity-manager";
-import { FindSelect } from "./types/find-select";
-import { EntityValues } from "./types/entity-values";
-import { DeleteOptions } from "./options/delete-options";
+import { CokeModel } from './coke-model';
+import { FindOptions } from './options/find-options';
+import { SaveOptions } from './options/save-options';
+import { EntityManager } from './entity-manager';
+import { FindSelect } from './types/find-select';
+import { EntityValues } from './types/entity-values';
+import { DeleteOptions } from './options/delete-options';
 
 export {
-   DeleteOptions,
-   FindOptions,
-   SaveOptions,
-   FindSelect,
-   EntityValues,
-   CokeModel,
-   EntityManager
-}
+	DeleteOptions,
+	FindOptions,
+	SaveOptions,
+	FindSelect,
+	EntityValues,
+	CokeModel,
+	EntityManager,
+};

--- a/src/manager/options/delete-options.ts
+++ b/src/manager/options/delete-options.ts
@@ -1,14 +1,27 @@
-import { QueryRunner } from "../../query-runner";
-import { EntitySubscriberInterface } from "../../metadata/event";
+import { QueryRunner } from '../../query-runner';
+import { EntitySubscriberInterface } from '../../metadata/event';
 
+/**
+ * Options for delete a record
+ */
 export class DeleteOptions<T = any> {
-   queryRunner: QueryRunner;
-   requester?: any;
-   subscriber?: EntitySubscriberInterface<T>;
 
-   constructor(options: DeleteOptions) {
-      this.queryRunner = options.queryRunner;
-      this.requester = options.requester;
-      this.subscriber = options.subscriber;
-   }
+	/**
+	 * Query Executor used for the operation.
+	 */
+	queryRunner: QueryRunner;
+
+	/**
+	 * Subscriber with events to be executed when deleting the record.
+	 */
+	subscriber?: EntitySubscriberInterface<T>;
+
+	/**
+	 * Default class constructor
+	 * @param {DeleteOptions} options Delete Options
+	 */
+	constructor(options: DeleteOptions) {
+		this.queryRunner = options.queryRunner;
+		this.subscriber = options.subscriber;
+	}
 }

--- a/src/manager/options/find-options.ts
+++ b/src/manager/options/find-options.ts
@@ -1,10 +1,16 @@
 import { QueryOrder, QueryWhere } from '../../query-builder';
+import { QueryRunner } from '../../query-runner';
 import { FindSelect } from '../types/find-select';
 
 /**
  * Options for query a record
  */
 export class FindOptions<T> {
+
+	/**
+	 * Query Executor used for the operation.
+	 */
+	queryRunner?: QueryRunner;
 
 	/**
 	 * Fields to be consulted.
@@ -45,19 +51,24 @@ export class FindOptions<T> {
 	roles?: string[];
 
 	/**
-	 * Default class constructor.
-	 * @param {FindOptions<T>} findOptions Find Options
+	 * Indicates whether load events should be executed.
 	 */
-	constructor(findOptions?: FindOptions<T>) {
-		if (findOptions) {
-			this.select = findOptions.select;
-			this.relations = findOptions.relations;
-			this.where = findOptions.where;
-			this.orderBy = findOptions.orderBy;
-			this.skip = findOptions.skip;
-			this.limit = findOptions.limit;
-			this.roles = findOptions.roles;
-		}
+	runAfterLoadEvent?: boolean = true
+
+	/**
+	 * Default class constructor.
+	 * @param {FindOptions<T>} options Find Options
+	 */
+	constructor(options?: FindOptions<T>) {
+		this.queryRunner = options?.queryRunner;
+		this.select = options?.select;
+		this.relations = options?.relations;
+		this.where = options?.where;
+		this.orderBy = options?.orderBy;
+		this.skip = options?.skip;
+		this.limit = options?.limit;
+		this.roles = options?.roles;
+		this.runAfterLoadEvent = options?.runAfterLoadEvent ?? true;
 	}
 
 }

--- a/src/manager/options/find-options.ts
+++ b/src/manager/options/find-options.ts
@@ -1,59 +1,63 @@
-import { ForeignKeyMetadata, EntityMetadata } from "../../metadata";
-import { QueryOrder, QueryWhere } from "../../query-builder";
-import { FindSelect } from "../types/find-select";
+import { QueryOrder, QueryWhere } from '../../query-builder';
+import { FindSelect } from '../types/find-select';
 
+/**
+ * Options for query a record
+ */
 export class FindOptions<T> {
-   select?: FindSelect[];
-   relations?: string[];
-   where?: QueryWhere<T> | QueryWhere<T>[];
-   orderBy?: QueryOrder<T>;
-   skip?: number;
-   limit?: number;
-   roles?: string[];
 
-   constructor(findOptions?: FindOptions<T>) {
-      if (findOptions) {
-         this.select = findOptions.select;
-         this.relations = findOptions.relations;
-         this.where = findOptions.where;
-         this.orderBy = findOptions.orderBy;
-         this.skip = findOptions.skip;
-         this.limit = findOptions.limit;
-         this.roles = findOptions.roles;
-      }
-   }
+	/**
+	 * Fields to be consulted.
+	 */
+	select?: FindSelect[];
 
-   public static loadDefaultOrderBy(entityMetadata: EntityMetadata, findOptions: FindOptions<any>): void {//, hierarchyRelation?: string): void {
-      let orderBy: any = findOptions.orderBy;
+	/**
+	 * Relationships to be loaded. If a relation field is entered, its relation
+	 * will be loaded automatically, it is not necessary to inform it in this
+	 * parameter.
+	 */
+	relations?: string[];
 
-      if (!orderBy) {
+	/**
+	 * Filters to be applied when querying records.
+	 */
+	where?: QueryWhere<T> | QueryWhere<T>[];
 
-         orderBy = entityMetadata.orderBy;
-         if (!orderBy) {
+	/**
+	 * Default ordering of the queried table. Ordering can also be added for
+	 * relation child tables.
+	 */
+	orderBy?: QueryOrder<T>;
 
-            orderBy = {};
-            for (const columnPropertyName of entityMetadata.primaryKey?.columns as string[]) {
-               orderBy[columnPropertyName] = 'ASC';         
-            }
+	/**
+	 * Number of initial records to be ignored in the query.
+	 */
+	skip?: number;
 
-         }
+	/**
+	 * Query record limit.
+	 */
+	limit?: number;
 
-      }
+	/**
+	 * Roles of the fields to be consulted.
+	 */
+	roles?: string[];
 
-      for (const columnPropertyName in orderBy) {
-         
-         const columnMetadata = entityMetadata.columns[columnPropertyName];
-         const relationMetadata: ForeignKeyMetadata | undefined = columnMetadata.relation;
-
-         if (relationMetadata) {
-            if (relationMetadata.type == 'OneToMany') {
-               delete (orderBy as any)[columnPropertyName];
-            }
-         }
-
-      }
-
-      findOptions.orderBy = orderBy;
-   }
+	/**
+	 * Default class constructor.
+	 * @param {FindOptions<T>} findOptions Find Options
+	 */
+	constructor(findOptions?: FindOptions<T>) {
+		if (findOptions) {
+			this.select = findOptions.select;
+			this.relations = findOptions.relations;
+			this.where = findOptions.where;
+			this.orderBy = findOptions.orderBy;
+			this.skip = findOptions.skip;
+			this.limit = findOptions.limit;
+			this.roles = findOptions.roles;
+		}
+	}
 
 }

--- a/src/manager/options/save-options.ts
+++ b/src/manager/options/save-options.ts
@@ -1,19 +1,49 @@
-import { ForeignKeyMetadata } from "../../metadata";
-import { QueryRunner } from "../../query-runner";
-import { EntitySubscriberInterface } from "../../metadata/event";
+import { ForeignKeyMetadata } from '../../metadata';
+import { QueryRunner } from '../../query-runner';
+import { EntitySubscriberInterface } from '../../metadata/event';
 
+/**
+ * Options for save a record
+ */
 export class SaveOptions<T = any> {
-   queryRunner: QueryRunner;
-   relation?: ForeignKeyMetadata;
-   requester?: any;
-   subscriber?: EntitySubscriberInterface<T>;
-   recreateObjects?: boolean;
 
-   constructor(options: SaveOptions) {
-      this.queryRunner = options.queryRunner;
-      this.relation = options.relation;
-      this.requester = options.requester;
-      this.subscriber = options.subscriber;
-      this.recreateObjects = options.recreateObjects ?? true;
-   }
+	/**
+	 * Query Executor used for the operation.
+	 */
+	queryRunner: QueryRunner;
+
+	/**
+	 * Entity requesting record saving.
+	 */
+	requester?: any;
+
+	/**
+	 * Relation of the table that requested the save to the table to be saved.
+	 */
+	relation?: ForeignKeyMetadata;
+
+	/**
+	 * Subscriber with events to be executed when saving the record.
+	 */
+	subscriber?: EntitySubscriberInterface<T>;
+
+	/**
+	 * Indicates whether the objects to be saved must be recreated, this is used
+	 * in cases where relationship records are saved, because when starting the
+	 * process all objects have already been created, it is not necessary to
+	 * 7create them all again.
+	 */
+	recreateObjects?: boolean;
+
+	/**
+	 * Default class constructor
+	 * @param {SaveOptions} options Save Options
+	 */
+	constructor(options: SaveOptions) {
+		this.queryRunner = options.queryRunner;
+		this.requester = options.requester;
+		this.relation = options.relation;
+		this.subscriber = options.subscriber;
+		this.recreateObjects = options.recreateObjects ?? true;
+	}
 }

--- a/src/metadata/metadata.ts
+++ b/src/metadata/metadata.ts
@@ -3,7 +3,7 @@ import { SimpleMap } from '../common';
 import { Connection } from '../connection';
 import { DecoratorsStore } from '../decorators';
 import { DefaultColumnOptions } from '../drivers';
-import { ColumnMetadataNotLocatedError, EntityHasNoPrimaryKeyError, EntityMetadataNotLocatedError, InvalidTriggerOptionError, ReferencedColumnMetadataNotLocatedError, ReferencedEntityMetadataNotLocatedError } from '../errors';
+import { EntityHasNoPrimaryKeyError, EntityMetadataNotLocatedError, InvalidTriggerOptionError, ReferencedColumnMetadataNotLocatedError, ReferencedEntityMetadataNotLocatedError } from '../errors';
 import { MigrationModel } from '../migration';
 import { NamingStrategy } from '../naming-strategy';
 import { OrmUtils } from '../utils';
@@ -206,7 +206,7 @@ export class Metadata {
 
 					referencedColumnOptions = DecoratorsStore.getColumn(referencedEntityOptions.inheritances, columnOption.relation.referencedColumn);
 					if (!referencedColumnOptions) {
-						throw new ReferencedColumnMetadataNotLocatedError(entityMetadata.className, columnOption.relation.referencedEntity, columnOption.relation.referencedColumn);
+						throw new ReferencedColumnMetadataNotLocatedError(entityMetadata.className, columnOption.propertyName, columnOption.relation.referencedEntity, columnOption.relation.referencedColumn);
 					}
 
 					referencedDefaultColumnOptions = this.connection.driver.detectColumnDefaults(referencedColumnOptions);
@@ -330,7 +330,7 @@ export class Metadata {
 				const referencedColumnMetadata: ColumnMetadata = referencedEntityMetadata.columns[referencedColumnName];
 
 				if (!referencedColumnMetadata) {
-					throw new ColumnMetadataNotLocatedError(referencedEntity, referencedColumnName);
+					throw new ReferencedColumnMetadataNotLocatedError(entityClassName, columnPropertyName, referencedEntity, referencedColumnName);
 				}
 
 				if (sourceColumnMetadata.relation?.type == 'OneToMany') {

--- a/src/naming-strategy/naming-strategy.ts
+++ b/src/naming-strategy/naming-strategy.ts
@@ -73,7 +73,13 @@ export class NamingStrategy {
       if (triggerOptions.name) {
          return triggerOptions.name;
       }
-      return `${entityMetadata.name}_${StringUtils.snakeCase(triggerOptions.trigger.constructor.name)}`;
+
+      let triggerName: string = `tgg_${entityMetadata.name}_${StringUtils.snakeCase(triggerOptions.trigger.constructor.name)}`;
+      if (triggerName.endsWith('trigger')) {
+         triggerName = triggerName.substring(0, triggerName.lastIndexOf('trigger') - 1);
+      }
+
+      return triggerName;
    }
 
    /**

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -72,6 +72,9 @@ export async function test() {
 	console.log('loadPrimaryKey', city);
 
 	const cities = await connection.getEntityManager(CityModel).find({
+		select: [
+			'name',
+		],
 		where: [
 			{
 				name: { equal: 'Guaporé' },
@@ -90,7 +93,10 @@ export async function test() {
 				],
 			},
 		],
-	});
+		orderBy: {
+			name: 'ASC',
+		},
+	} as any);
 	console.log('find', cities);
 
 	city = connection.getEntityManager(CityModel).create({
@@ -309,12 +315,12 @@ export async function test() {
 				},
 			},
 			{
-				id: 6,
+				id: 149,
 			},
 			{
 				id: {
 					greaterThanOrEqual: 0,
-					lessThanOrEqual: 50,
+					lessThanOrEqual: 200,
 				},
 			},
 		],

--- a/src/samples/migrations/2021-07-24-06-06-29-0048-migration.ts
+++ b/src/samples/migrations/2021-07-24-06-06-29-0048-migration.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface } from "../../migration";
+import { QueryRunner } from "../../query-runner";
+
+export class migration202107240606290048 implements MigrationInterface {
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP TRIGGER "tgg_entities_addresses_set_default_address_trigger_test" ON "public"."entities_addresses";`);
+		await queryRunner.query(`DROP FUNCTION "public"."tgg_entities_addresses_set_default_address_trigger_test"();`);
+		await queryRunner.query(`CREATE FUNCTION "public"."tgg_entities_addresses_set_default_address"() RETURNS trigger LANGUAGE 'plpgsql' VOLATILE AS $BODY$ DECLARE hasAddress INTEGER; DECLARE hasAddressTest INTEGER; BEGIN  
+		hasAddress = 0;
+		
+		SELECT count(*)
+		From entities_addresses
+		Where entity_id = NEW.entity_id
+		Into hasAddress;
+		
+		IF ((NEW.is_default = true) and (hasAddress > 0)) THEN
+			Update entities_addresses
+			Set is_default = false
+			Where entity_id = NEW.entity_id
+			and id <> NEW.id;
+		ELSEIF (hasAddress <= 0) THEN
+			NEW.is_default = true;
+		ELSE
+			NEW.is_default = false;
+		END IF;
+		
+		RETURN NEW; END $BODY$;`);
+		await queryRunner.query(`CREATE TRIGGER "tgg_entities_addresses_set_default_address" BEFORE INSERT OR UPDATE ON "public"."entities_addresses" FOR EACH ROW  EXECUTE FUNCTION "public"."tgg_entities_addresses_set_default_address"();`);
+		await queryRunner.query(`COMMENT ON TRIGGER "tgg_entities_addresses_set_default_address" ON "public"."entities_addresses" IS '803ada6edd6f520eb2c5da7961ea659e9a13530b';`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		
+	}
+
+}

--- a/src/samples/triggers/entity/set_default_addres.trigger.ts
+++ b/src/samples/triggers/entity/set_default_addres.trigger.ts
@@ -7,12 +7,13 @@ import { EntityAddressModel } from '../../models/entity/entity-address.model';
  * Test Trigger
  */
 @Trigger(EntityAddressModel, { fires: 'BEFORE', events: ['INSERT', 'UPDATE'] })
-export class SetDefaultAddress implements TriggerInterface {
+export class SetDefaultAddressTrigger implements TriggerInterface {
 
 	// when = `OLD is null or OLD.is_default <> NEW.is_default`;
 
 	variables = [
 		{ name: 'hasAddress', type: 'INTEGER' },
+		{ name: 'hasAddressTest', type: 'INTEGER' },
 	]
 
 	code = ` 


### PR DESCRIPTION
- Adicionado o parâmetro `queryRunner` dentro `FindOptions`, e removido do método `find` do `EntityManager`.
- Correção nos eventos `beforeTransactionCommit`, `afterTransactionCommit`, `beforeTransactionRollback` e `afterTransactionRollback` que o `this` ficava undefined.
- Efetuado ajustes em relação ao método `release` do `client` do pool que em alguns casos ficava undefined e causava erro.
- Efetuado correção na geração da migration das triggers que não declarava corretamente as variáveis quando tinha mais de uma variável.
- Adicionado documentação em algumas classes.