### PR TITLE
Versão 0.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "",
   "license": "BSD-3-Clause",
   "author": {

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,6 +2,10 @@
 
 ## Geral
 
+* Implementar o método "validade" no subscriber
+* Quando o default do campo é uma string, não está adicionando as aspas simples na migration
+* Mensagem customizada de erro das relations
+* Implementar 'validators' nas colunas
 * Validar se vai gerar duas tabelas com o mesmo nome
 * Analisar porque ele mandar deletar PK nas migrations sem ter elas criadas em alguns casos (marketplace)
 * Validar caso seja adicionado uma mesma unique ou indice na mesma tabela

--- a/src/drivers/databases/postgres/postgres-driver.ts
+++ b/src/drivers/databases/postgres/postgres-driver.ts
@@ -90,8 +90,9 @@ export class PostgresDriver extends Driver {
          -- load columns (with constraints, indexs and sequences)
          LEFT JOIN (
          
-            SELECT c.table_schema, c.table_name, json_agg(json_build_object('column_name', c.column_name, 'ordinal_position', c.ordinal_position, 'column_default', c.column_default, 'is_nullable', c.is_nullable, 'data_type', c.data_type, 'numeric_precision', c.numeric_precision, 'numeric_scale', c.numeric_scale, 'constraints', constraints, 'indexs', indexs, 'sequences', sequences) ORDER BY c.ordinal_position) as columns
+            SELECT c.table_schema, c.table_name, json_agg(json_build_object('column_name', c.column_name, 'ordinal_position', c.ordinal_position, 'column_default', c.column_default, 'is_nullable', c.is_nullable, 'data_type', COALESCE(et.data_type, c.data_type)||(CASE WHEN c.data_type = 'ARRAY' THEN '[]' ELSE '' END), 'numeric_precision', c.numeric_precision, 'numeric_scale', c.numeric_scale, 'constraints', constraints, 'indexs', indexs, 'sequences', sequences) ORDER BY c.ordinal_position) as columns
             FROM information_schema.columns c
+				LEFT JOIN information_schema.element_types et ON (et.object_catalog = c.table_catalog AND et.object_schema = c.table_schema AND et.object_type = 'TABLE' AND et.object_name = c.table_name AND et.collection_type_identifier::integer = c.ordinal_position)
 
             -- load constraints
             LEFT JOIN (

--- a/src/drivers/databases/postgres/postgres-query-builder-driver.ts
+++ b/src/drivers/databases/postgres/postgres-query-builder-driver.ts
@@ -101,7 +101,7 @@ export class PostgresQueryBuilderDriver extends QueryBuilderDriver {
 
 		}
 
-		if ((columnMetadata.default?.toString() ?? '') != currentColumnSchema.default) {
+		if ((columnMetadata.default?.toString() ?? '') != currentColumnSchema.default && (columnMetadata.default?.toString() ?? '')+'::'+columnMetadata.type != currentColumnSchema.default) {
 
 			if (currentColumnSchema.default != null && columnMetadata.default == null) {
 				sqls.push(`${alterTable} COLUMN "${columnMetadata.name}" DROP DEFAULT;`);

--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -190,8 +190,8 @@ export abstract class Driver {
             throw new InvalidColumnOptionError(`The '${column.propertyName}' property of the '${entityMetadata.className}' entity has a unique key or unique index and is not mandatory, if one of the columns is null the record may be duplicated`);
          }
 
-         if (column.enum && ',integer,bigint'.indexOf(',' + column.type) < 0) {
-            throw new InvalidColumnOptionError(`The '${column.propertyName}' property of the '${entityMetadata.className}' with the enum '${column.enum}' must be of type 'integer' or 'bigint'`);
+         if (column.enum && ',integer,integer[],bigint,bigint[]'.indexOf(',' + column.type) < 0) {
+            throw new InvalidColumnOptionError(`The '${column.propertyName}' property of the '${entityMetadata.className}' with the enum '${column.enum}' must be of type 'integer', 'integer[]', 'bigint' or 'bigint[]'`);
          }
          
       }


### PR DESCRIPTION
- Correção quando é gerado as migrations e o tipo do campo é array, pois sempre mandava recriar as colunas.
- Liberado o tipo integer[] e bigint[] como array na validação de tipos de campos liberados para uso de enumerados.