### PR TITLE
Versão 0.14.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "",
   "license": "BSD-3-Clause",
   "author": {

--- a/src/manager/coke-model.ts
+++ b/src/manager/coke-model.ts
@@ -113,6 +113,7 @@ export abstract class CokeModel {
 			// load the object saved in the database to pass on events
 			if (subscribers.some((subscriber) => subscriber?.beforeUpdate || subscriber?.afterUpdate) || saveOptions?.subscriber?.beforeUpdate || saveOptions?.subscriber?.afterUpdate || hasTransactionEvents) {
 				databaseData = await entityManager.findOne({
+					queryRunner: saveOptions.queryRunner,
 					where: where,
 				});
 			}
@@ -239,69 +240,53 @@ export abstract class CokeModel {
 
 			// events related to transaction commit
 			for (const subscriber of subscribers.filter((subscriber) => subscriber?.beforeTransactionCommit)) {
-				if (subscriber?.beforeTransactionCommit) {
-					saveOptions.queryRunner.beforeTransactionCommit.push(async () => {
-						if (subscriber?.beforeTransactionCommit) {
-							await subscriber.beforeTransactionCommit(event);
-						}
-					});
-				}
+				saveOptions.queryRunner.beforeTransactionCommit.push({
+					subscriber,
+					event,
+				});
 			}
 			if (saveOptions?.subscriber?.beforeTransactionCommit) {
-				saveOptions.queryRunner.beforeTransactionCommit.push(async () => {
-					if (saveOptions?.subscriber?.beforeTransactionCommit) {
-						await saveOptions.subscriber.beforeTransactionCommit(event);
-					}
+				saveOptions.queryRunner.beforeTransactionCommit.push({
+					subscriber: saveOptions?.subscriber,
+					event,
 				});
 			}
 			for (const subscriber of subscribers.filter((subscriber) => subscriber?.afterTransactionCommit)) {
-				if (subscriber?.afterTransactionCommit) {
-					saveOptions.queryRunner.afterTransactionCommit.push(async () => {
-						if (subscriber?.afterTransactionCommit) {
-							await subscriber.afterTransactionCommit(event);
-						}
-					});
-				}
+				saveOptions.queryRunner.afterTransactionCommit.push({
+					subscriber,
+					event,
+				});
 			}
 			if (saveOptions?.subscriber?.afterTransactionCommit) {
-				saveOptions.queryRunner.afterTransactionCommit.push(async () => {
-					if (saveOptions?.subscriber?.afterTransactionCommit) {
-						await saveOptions.subscriber.afterTransactionCommit(event);
-					}
+				saveOptions.queryRunner.afterTransactionCommit.push({
+					subscriber: saveOptions?.subscriber,
+					event,
 				});
 			}
 
 			// events related to transaction rollback
 			for (const subscriber of subscribers.filter((subscriber) => subscriber?.beforeTransactionRollback)) {
-				if (subscriber?.beforeTransactionRollback) {
-					saveOptions.queryRunner.beforeTransactionRollback.push(async () => {
-						if (subscriber?.beforeTransactionRollback) {
-							await subscriber.beforeTransactionRollback(event);
-						}
-					});
-				}
+				saveOptions.queryRunner.beforeTransactionRollback.push({
+					subscriber,
+					event,
+				});
 			}
 			if (saveOptions?.subscriber?.beforeTransactionRollback) {
-				saveOptions.queryRunner.beforeTransactionRollback.push(async () => {
-					if (saveOptions?.subscriber?.beforeTransactionRollback) {
-						await saveOptions?.subscriber.beforeTransactionRollback(event);
-					}
+				saveOptions.queryRunner.beforeTransactionRollback.push({
+					subscriber: saveOptions?.subscriber,
+					event,
 				});
 			}
 			for (const subscriber of subscribers.filter((subscriber) => subscriber?.afterTransactionRollback)) {
-				if (subscriber?.afterTransactionRollback) {
-					saveOptions.queryRunner.afterTransactionRollback.push(async () => {
-						if (subscriber?.afterTransactionRollback) {
-							await subscriber.afterTransactionRollback(event);
-						}
-					});
-				}
+				saveOptions.queryRunner.afterTransactionRollback.push({
+					subscriber,
+					event,
+				});
 			}
 			if (saveOptions?.subscriber?.afterTransactionRollback) {
-				saveOptions.queryRunner.afterTransactionRollback.push(async () => {
-					if (saveOptions?.subscriber?.afterTransactionRollback) {
-						await saveOptions?.subscriber.afterTransactionRollback(event);
-					}
+				saveOptions.queryRunner.afterTransactionRollback.push({
+					subscriber: saveOptions?.subscriber,
+					event,
 				});
 			}
 
@@ -513,6 +498,7 @@ export abstract class CokeModel {
 			let databaseData: this | undefined = undefined;
 			if (subscribers.some((subscriber) => subscriber?.beforeUpdate || subscriber?.afterUpdate || subscriber?.afterTransactionCommit || subscriber?.beforeTransactionCommit || subscriber?.afterTransactionRollback || subscriber?.beforeTransactionRollback)) {
 				databaseData = await entityManager.findOne({
+					queryRunner: deleteOptions.queryRunner,
 					where: where,
 				});
 			}
@@ -574,30 +560,30 @@ export abstract class CokeModel {
 
 				// events related to transaction commit
 				for (const subscriber of subscribers.filter((subscriber) => subscriber?.beforeTransactionCommit)) {
-					if (subscriber?.beforeTransactionCommit) {
-						const beforeTransactionCommit = subscriber.beforeTransactionCommit;
-						deleteOptions.queryRunner.beforeTransactionCommit.push(() => beforeTransactionCommit(event));
-					}
+					deleteOptions.queryRunner.beforeTransactionCommit.push({
+						subscriber,
+						event,
+					});
 				}
 				for (const subscriber of subscribers.filter((subscriber) => subscriber?.afterTransactionCommit)) {
-					if (subscriber?.afterTransactionCommit) {
-						const afterTransactionCommit = subscriber.afterTransactionCommit;
-						deleteOptions.queryRunner.afterTransactionCommit.push(() => afterTransactionCommit(event));
-					}
+					deleteOptions.queryRunner.afterTransactionCommit.push({
+						subscriber,
+						event,
+					});
 				}
 
 				// events related to transaction rollback
 				for (const subscriber of subscribers.filter((subscriber) => subscriber?.beforeTransactionRollback)) {
-					if (subscriber?.beforeTransactionRollback) {
-						const beforeTransactionRollback = subscriber.beforeTransactionRollback;
-						deleteOptions.queryRunner.beforeTransactionRollback.push(() => beforeTransactionRollback(event));
-					}
+					deleteOptions.queryRunner.beforeTransactionRollback.push({
+						subscriber,
+						event,
+					});
 				}
 				for (const subscriber of subscribers.filter((subscriber) => subscriber?.afterTransactionRollback)) {
-					if (subscriber?.afterTransactionRollback) {
-						const afterTransactionRollback = subscriber.afterTransactionRollback;
-						deleteOptions.queryRunner.afterTransactionRollback.push(() => afterTransactionRollback(event));
-					}
+					deleteOptions.queryRunner.afterTransactionRollback.push({
+						subscriber,
+						event,
+					});
 				}
 
 			}

--- a/src/query-runner/interfaces/transaction-event.interface.ts
+++ b/src/query-runner/interfaces/transaction-event.interface.ts
@@ -1,0 +1,6 @@
+import { EntityTransactionEventsInterface } from '../../metadata/event/interfaces/entity-transaction-events.interface';
+
+export interface TransactionEventInterface<TEvent> {
+   subscriber: EntityTransactionEventsInterface<any>;
+   event: TEvent;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
- Correção no performSave` e `performDelete` do `CokeModel`  para consultar o objeto no mesmo `queryRunner` da transação.
- Correção na forma que é executado os eventos `beforeTransactionCommit`, `afterTransactionCommit`, `beforeTransactionRollback` e `afterTransactionRollback` pois dentro do subscriber o `this` ficava `undefined`.