### PR TITLE
Versão 0.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "",
   "license": "BSD-3-Clause",
   "author": {

--- a/src/drivers/databases/postgres/postgres-driver.ts
+++ b/src/drivers/databases/postgres/postgres-driver.ts
@@ -141,7 +141,7 @@ export class PostgresDriver extends Driver {
                FROM information_schema.triggers g
                INNER JOIN pg_catalog.pg_trigger ON (pg_trigger.tgname = g.trigger_name)
                INNER JOIN pg_catalog.pg_depend ON (pg_depend.refobjid = pg_trigger.tgfoid)
-               INNER JOIN pg_catalog.pg_description ON (pg_description.objoid = pg_depend.objid)
+               LEFT JOIN pg_catalog.pg_description ON (pg_description.objoid = pg_depend.objid)
                GROUP BY trigger_catalog, trigger_schema, trigger_name, event_object_table, action_timing, pg_description.description) g
             GROUP BY trigger_catalog, trigger_schema, event_object_table) g on (g.trigger_catalog = t.table_catalog and g.trigger_schema = t.table_schema and g.event_object_table = t.table_name)
          

--- a/src/drivers/databases/postgres/postgres-query-builder-driver.ts
+++ b/src/drivers/databases/postgres/postgres-query-builder-driver.ts
@@ -149,7 +149,7 @@ export class PostgresQueryBuilderDriver extends QueryBuilderDriver {
 	}
 
 	public createTriggerFromMetadata(triggerMetadata: TriggerMetadata): string[] {
-		const variables = (triggerMetadata.trigger.variables ? `DECLARE ${triggerMetadata.trigger.variables.map((variable) => `${variable.name} ${variable.type}`).join('; DECLARE ')};` : '');
+		const variables = ((triggerMetadata.trigger.variables?.length ?? 0) > 0 ? `DECLARE ${triggerMetadata.trigger.variables?.map((variable) => `${variable.name} ${variable.type}`).join('; DECLARE ')};` : '');
 		return [
 			`CREATE FUNCTION "${triggerMetadata.entity.connection.options.schema ?? 'public'}"."${triggerMetadata.name}"() RETURNS trigger LANGUAGE 'plpgsql' VOLATILE AS $BODY$ ${variables} BEGIN ${triggerMetadata.trigger.code} END $BODY$;`,
 			`CREATE TRIGGER "${triggerMetadata.name}" ${triggerMetadata.trigger.fires} ${triggerMetadata.trigger.events.join(' OR ')} ON "${triggerMetadata.entity.connection.options.schema ?? 'public'}"."${triggerMetadata.entity.name}" FOR EACH ROW ${triggerMetadata.trigger.when ? ` WHEN ${triggerMetadata.trigger.when} ` : ''} EXECUTE FUNCTION "${triggerMetadata.entity.connection.options.schema ?? 'public'}"."${triggerMetadata.name}"();`,


### PR DESCRIPTION
- Correção na consulta de triggers que não eram listadas caso não tivesse comentarios.
- Correção na geração das triggers quando tinha a propriedade `variables` definida com um array em branco pois estava gerando uma SQL errada para criação da trigger.