### PR TITLE
Versão 0.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ricardocrescenti/coke-orm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "",
   "license": "BSD-3-Clause",
   "author": {

--- a/src/decorators/event/event-subscriber.ts
+++ b/src/decorators/event/event-subscriber.ts
@@ -1,13 +1,20 @@
-import { ConstructorTo } from "../../common";
-import { EntitySubscriberInterface } from "../../metadata";
-import { CokeModel } from "../../manager";
-import { DecoratorsStore } from "../decorators-store";
+import { ConstructorTo } from '../../common';
+import { EntitySubscriberInterface } from '../../metadata';
+import { CokeModel } from '../../manager';
+import { DecoratorsStore } from '../decorators-store';
 
-export function EventsSubscriber(entity: ConstructorTo<CokeModel>): ClassDecorator {
-   return function (target: Function) {
-      DecoratorsStore.addSubscriber({
-         target: entity,
-         subscriber: target as ConstructorTo<EntitySubscriberInterface<any>>
-      });
-   };
+/**
+ * Decorator for subscriber implementation
+ * @param {ConstructorTo} entity Model creation function
+ * @return {ClassDecorator} Function used to implement decorators
+ */
+export function EventsSubscriber(entity: ConstructorTo<CokeModel> | null): ClassDecorator {
+
+	return function(target: Function) {
+		DecoratorsStore.addSubscriber({
+			target: entity,
+			subscriber: target as ConstructorTo<EntitySubscriberInterface<any>>,
+		});
+	};
+
 }

--- a/src/metadata/event/subscriber-options.ts
+++ b/src/metadata/event/subscriber-options.ts
@@ -1,15 +1,22 @@
-import { ConstructorTo } from "../../common";
-import { CokeModel } from "../../manager";
-import { EntitySubscriberInterface } from "./interfaces/entity-subscriber.interface";
+import { ConstructorTo } from '../../common';
+import { CokeModel } from '../../manager';
+import { EntitySubscriberInterface } from './interfaces/entity-subscriber.interface';
 
+/**
+ * Options for configuring subscribers
+ */
 export class SubscriberOptions {
 
-   public readonly target: Function;
-   public readonly subscriber: ConstructorTo<EntitySubscriberInterface<CokeModel>>;
+	public readonly target: Function | null;
+	public readonly subscriber: ConstructorTo<EntitySubscriberInterface<CokeModel>>;
 
-   constructor(options: SubscriberOptions) {
-      this.target = options.target;
-      this.subscriber = options.subscriber;
-   }
+	/**
+	 * Class default constructor
+	 * @param {SubscriberOptions} options Options for configuring subscribers
+	 */
+	constructor(options: SubscriberOptions) {
+		this.target = options.target;
+		this.subscriber = options.subscriber;
+	}
 
 }


### PR DESCRIPTION
Alteração tipo da propriedade `target` do `SubscriberOptions` para aceitar uma `Function` ou `null`, por causa dos Subscribers gerais, que podem ser usados para todos os models.